### PR TITLE
Add a sample ansible playbook for creating an client-to-site VPN server (Beta) in VPC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 terraform-single/terraform.tfstate
 terraform-single/terraform.tfstate.backup
 terraform-single/.terraform.tfstate.lock.info
+ibmcloud-vpnserver/*.pem
+ibmcloud-vpnserver/*.key
+ibmcloud-vpnserver/*.ovpn

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ terraform-single/.terraform.tfstate.lock.info
 ibmcloud-vpnserver/*.pem
 ibmcloud-vpnserver/*.key
 ibmcloud-vpnserver/*.ovpn
+ibmcloud-vpnserver/*.password

--- a/ibmcloud-vpnserver/README.md
+++ b/ibmcloud-vpnserver/README.md
@@ -1,0 +1,38 @@
+# Deploys a client-to-site VPN server (Beta) in zVSI with Ansible
+
+This is a sample playbook for generating a client-to-site VPN server on IBM Cloud. This creates a single subnetwork VPC
+and deploys a client-to-site VPN server into it. This playbook produces certificates for use by the VPN server and client.
+It does not establish separate, by userid, login credentials, so anyone with the resulting ovpn file will be able to
+establish a VPN to the environment. Finally this playbook uses the IBM Cloud API to deploy the client-to-site VPN server.
+Once the ibm.cloudcollection ansible collection has been enriched to deploy the VPN server, it should be used instead of this
+project.
+
+## Preparations
+
+1. Install Python3
+2. Install [RedHat Ansible] 2.9+
+   - `pip install "ansible>=2.9.2"`
+3. Install ansible collections
+   - `ansible-galaxy collection install ibm.cloudcollection`
+   - `ansible-galaxy collection install community.crypto`
+4. Adjust [ansible settings](group_vars/all.yml)
+5. Ensure you have an `IC_API_KEY` environment variable set up with your
+   IBM Cloud API key
+    - this will likely require a paying account
+    - you can create an API account by visiting the [IBM Cloud API keys page](https://cloud.ibm.com/iam/apikeys). Ensure you have
+      selected the account you want to use before creating the key as the key will be associated to the account you have selected
+      at the time of creation.
+    - If you have downloaded your `apikey.json` file from the IBM Cloud UI you may use this command:
+      `export IC_API_KEY=$(cat ~/apikey.json | jq -r .apikey)`
+
+## Create
+
+- `ansible-playbook create.yml`
+
+If you want to use a different region add `-e region=<MZR name>` to the above command. Example: `-e region=br-sao`
+
+## Destroy
+
+1. `ansible-playbook destroy.yml`
+   - Note: VPC and subnetwork will not be deleted - comment in last two tasks in
+     [destroy.yml](destroy.yml) if you want them deleted.

--- a/ibmcloud-vpnserver/README.md
+++ b/ibmcloud-vpnserver/README.md
@@ -1,4 +1,4 @@
-# Deploys a client-to-site VPN server (Beta) in zVSI with Ansible
+# Deploys a client-to-site VPN server (Beta) in VPC with Ansible
 
 This is a sample playbook for generating a client-to-site VPN server on IBM Cloud. This creates a single subnetwork VPC
 and deploys a client-to-site VPN server into it. This playbook produces certificates for use by the VPN server and client.
@@ -34,5 +34,5 @@ If you want to use a different region add `-e region=<MZR name>` to the above co
 ## Destroy
 
 1. `ansible-playbook destroy.yml`
-   - Note: VPC and subnetwork will not be deleted - comment in last two tasks in
-     [destroy.yml](destroy.yml) if you want them deleted.
+   - Note: The client-to-site VPN server (Beta), VPC and subnetwork, and Certificate Manager will not be deleted by default - adjust settings in [ansible settings](group_vars/all.yml)
+   if you want them deleted.

--- a/ibmcloud-vpnserver/ansible.cfg
+++ b/ibmcloud-vpnserver/ansible.cfg
@@ -1,0 +1,6 @@
+[defaults]
+fact_caching = jsonfile
+fact_caching_connection = .cache
+
+[ssh_connection]
+pipelining = True

--- a/ibmcloud-vpnserver/create.yml
+++ b/ibmcloud-vpnserver/create.yml
@@ -1,0 +1,10 @@
+---
+- name: Preparing a client-to-site VPN server (Beta) on IBM Cloud
+  hosts: localhost
+  connection: local
+  roles:
+    - ibmcloud-vpc
+    - ibmcloud-certificates
+    - ibmcloud-vpn-restapi
+  environment:
+    - IC_REGION: "{{ region }}"

--- a/ibmcloud-vpnserver/destroy.yml
+++ b/ibmcloud-vpnserver/destroy.yml
@@ -1,0 +1,12 @@
+---
+- name: Destroying a client-to-site VPN server (Beta) on IBM Cloud
+  hosts: localhost
+  connection: local
+  vars:
+    - mode: "destroy"
+  roles:
+    - ibmcloud-vpn-restapi
+    - ibmcloud-vpc
+    - ibmcloud-certificates
+  environment:
+    - IC_REGION: "{{ region }}"

--- a/ibmcloud-vpnserver/group_vars/all.yml
+++ b/ibmcloud-vpnserver/group_vars/all.yml
@@ -6,14 +6,14 @@ region: "jp-tok"
 certificate_service_name: "CertificateManager-vpnserver"
 
 # The region in which to deploy the certificate manager. Note that the free plan service
-# is not available in Sao Paulo.
+# is not available in all regions.
 certificate_service_region: "{{region}}"
 
 # The certificate authority you wish to use for your VPN server and client.
 ca:
   x509_certificate_file: "ibmcloud.ca.pem"
   x509_key_file: "ibmcloud.ca.key"
-  passphrase: "passw0rd"
+  passphrase: "{{lookup('password', 'ibmcloud.ca.password chars=ascii_letters,hexdigits length=12')}}"
   common_name: "VPN Server CA for {{region}}"
 
 # The server certificate you wish to use for your VPN server.

--- a/ibmcloud-vpnserver/group_vars/all.yml
+++ b/ibmcloud-vpnserver/group_vars/all.yml
@@ -5,24 +5,28 @@ region: "jp-tok"
 
 certificate_service_name: "CertificateManager-vpnserver"
 
+# The region in which to deploy the certificate manager. Note that the free plan service
+# is not available in Sao Paulo.
+certificate_service_region: "{{region}}"
+
 # The certificate authority you wish to use for your VPN server and client.
 ca:
   x509_certificate_file: "ibmcloud.ca.pem"
   x509_key_file: "ibmcloud.ca.key"
   passphrase: "passw0rd"
-  common_name: "VPN Server CA"
+  common_name: "VPN Server CA for {{region}}"
 
 # The server certificate you wish to use for your VPN server.
 vpnserver:
   x509_certificate_file: "ibmcloud.vpnserver.pem"
   x509_key_file: "ibmcloud.vpnserver.key"
-  common_name: "VPN Server"
+  common_name: "VPN Server for {{region}}"
 
 # The client certificate you wish to use for your VPN client.
 vpnclient:
   x509_certificate_file: "ibmcloud.vpnclient.pem"
   x509_key_file: "ibmcloud.vpnclient.key"
-  common_name: "VPN Client"
+  common_name: "VPN Client for {{region}}"
 
 
 # Name for the VPC

--- a/ibmcloud-vpnserver/group_vars/all.yml
+++ b/ibmcloud-vpnserver/group_vars/all.yml
@@ -7,25 +7,25 @@ certificate_service_name: "CertificateManager-vpnserver"
 
 # The region in which to deploy the certificate manager. Note that the free plan service
 # is not available in all regions.
-certificate_service_region: "{{region}}"
+certificate_service_region: "us-south"
 
 # The certificate authority you wish to use for your VPN server and client.
 ca:
-  x509_certificate_file: "ibmcloud.ca.pem"
-  x509_key_file: "ibmcloud.ca.key"
+  x509_certificate_file: "{{region}}.ca.pem"
+  x509_key_file: "{{region}}.ca.key"
   passphrase: "{{lookup('password', 'ibmcloud.ca.password chars=ascii_letters,hexdigits length=12')}}"
   common_name: "VPN Server CA for {{region}}"
 
 # The server certificate you wish to use for your VPN server.
 vpnserver:
-  x509_certificate_file: "ibmcloud.vpnserver.pem"
-  x509_key_file: "ibmcloud.vpnserver.key"
+  x509_certificate_file: "{{region}}.vpnserver.pem"
+  x509_key_file: "{{region}}.vpnserver.key"
   common_name: "VPN Server for {{region}}"
 
 # The client certificate you wish to use for your VPN client.
 vpnclient:
-  x509_certificate_file: "ibmcloud.vpnclient.pem"
-  x509_key_file: "ibmcloud.vpnclient.key"
+  x509_certificate_file: "{{region}}.vpnclient.pem"
+  x509_key_file: "{{region}}.vpnclient.key"
   common_name: "VPN Client for {{region}}"
 
 
@@ -48,7 +48,7 @@ vpn-ansible:
     client_ip_pool: "10.2.0.0/16"
 
 # Name for the resulting OpenVPN client configuration file.
-ovpn_config_file: "ibmcloud.ovpn"
+ovpn_config_file: "{{region}}.ovpn"
 
 # If destroy_vpn is enabled then the destroy playbook will delete the client-to-site VPN server (Beta)
 # destroy_vpn: True

--- a/ibmcloud-vpnserver/group_vars/all.yml
+++ b/ibmcloud-vpnserver/group_vars/all.yml
@@ -1,0 +1,60 @@
+# Region to deploy
+region: "jp-tok"
+# region: "br-sao"
+# region: "eu-gb"
+
+certificate_service_name: "CertificateManager-vpnserver"
+
+# The certificate authority you wish to use for your VPN server and client.
+ca:
+  x509_certificate_file: "ibmcloud.ca.pem"
+  x509_key_file: "ibmcloud.ca.key"
+  passphrase: "passw0rd"
+  common_name: "VPN Server CA"
+
+# The server certificate you wish to use for your VPN server.
+vpnserver:
+  x509_certificate_file: "ibmcloud.vpnserver.pem"
+  x509_key_file: "ibmcloud.vpnserver.key"
+  common_name: "VPN Server"
+
+# The client certificate you wish to use for your VPN client.
+vpnclient:
+  x509_certificate_file: "ibmcloud.vpnclient.pem"
+  x509_key_file: "ibmcloud.vpnclient.key"
+  common_name: "VPN Client"
+
+
+# Name for the VPC
+vpc_name: vpn-ansible
+
+# components for the VPC created objects (VPC, subnetworks, security group, VPN server)
+vpn-ansible:
+  subnets:
+  - name: "{{ vpc_name }}-subnet-1"
+    zone: "{{region}}-1"
+  security_group:
+    tcp:
+    - 443
+    - 80
+    - 22
+  vpn:
+    name: "{{ vpc_name }}-vpnserver"
+    zone: "{{region}}-1"
+    client_ip_pool: "10.2.0.0/16"
+
+# Name for the resulting OpenVPN client configuration file.
+ovpn_config_file: "ibmcloud.ovpn"
+
+# If destroy_vpn is enabled then the destroy playbook will delete the client-to-site VPN server (Beta)
+# destroy_vpn: True
+destroy_vpn: False
+
+# If destroy_vpc is enabled then the destroy playbook will delete the subnets and the vpc. 
+# Note that destroy_vpn must also be set to True for the VPC to be successfully deleted.
+# destroy_vpc: True
+destroy_vpc: False
+
+# If destroy_certmgr is enabled then the destroy playbook will delete the Certificate Manager resource
+# destroy_certmgr: True
+destroy_certmgr: False

--- a/ibmcloud-vpnserver/roles/ibmcloud-certificates/defaults/main.yml
+++ b/ibmcloud-vpnserver/roles/ibmcloud-certificates/defaults/main.yml
@@ -1,4 +1,5 @@
 certificate_service_name: "CertificateManager-vpnserver"
+certificate_service_region: "{{region}}"
 ca:
   x509_certificate_file: "ibmcloud.ca.pem"
   x509_key_file: "ibmcloud.ca.key"

--- a/ibmcloud-vpnserver/roles/ibmcloud-certificates/defaults/main.yml
+++ b/ibmcloud-vpnserver/roles/ibmcloud-certificates/defaults/main.yml
@@ -1,0 +1,18 @@
+certificate_service_name: "CertificateManager-vpnserver"
+ca:
+  x509_certificate_file: "ibmcloud.ca.pem"
+  x509_key_file: "ibmcloud.ca.key"
+  passphrase: "passw0rd"
+  common_name: "VPN Server CA"
+vpnserver:
+  x509_certificate_file: "ibmcloud.vpnserver.pem"
+  x509_key_file: "ibmcloud.vpnserver.key"
+  common_name: "VPN Server"
+vpnclient:
+  x509_certificate_file: "ibmcloud.vpnclient.pem"
+  x509_key_file: "ibmcloud.vpnclient.key"
+  common_name: "VPN Client"
+
+destroy_certmgr: false
+
+mode: "create"

--- a/ibmcloud-vpnserver/roles/ibmcloud-certificates/defaults/main.yml
+++ b/ibmcloud-vpnserver/roles/ibmcloud-certificates/defaults/main.yml
@@ -3,7 +3,7 @@ certificate_service_region: "{{region}}"
 ca:
   x509_certificate_file: "ibmcloud.ca.pem"
   x509_key_file: "ibmcloud.ca.key"
-  passphrase: "passw0rd"
+  passphrase: "{{lookup('password', 'ibmcloud.ca.password chars=ascii_letters,hexdigits length=12')}}"
   common_name: "VPN Server CA"
 vpnserver:
   x509_certificate_file: "ibmcloud.vpnserver.pem"

--- a/ibmcloud-vpnserver/roles/ibmcloud-certificates/meta/requirements.yml
+++ b/ibmcloud-vpnserver/roles/ibmcloud-certificates/meta/requirements.yml
@@ -1,0 +1,5 @@
+collections:
+  - name: ibm.cloudcollection
+    version: 1.35.0
+  - name: community.crypto
+    version: 2.1.0

--- a/ibmcloud-vpnserver/roles/ibmcloud-certificates/tasks/create.yml
+++ b/ibmcloud-vpnserver/roles/ibmcloud-certificates/tasks/create.yml
@@ -4,7 +4,7 @@
   - name: provision certificate manager resource instance
     ibm.cloudcollection.ibm_resource_instance:
       name: "{{ certificate_service_name }}"
-      location: "{{ region }}"
+      location: "{{ certificate_service_region }}"
       service: "cloudcerts"
       plan: "free"
     register: resource_instance_output
@@ -18,6 +18,7 @@
 - name: Retrieve list of certificates already deployed
   ibm.cloudcollection.ibm_certificate_manager_certificates_info:
     certificate_manager_instance_id: "{{cms.id}}"
+    region: "{{ certificate_service_region }}"
   register: cms_certificates_info
 
 - debug:
@@ -78,7 +79,7 @@
     ibm.cloudcollection.ibm_certificate_manager_import:
       certificate_manager_instance_id: "{{ cms.id }}"
       name: "{{ ca.common_name }}"
-      region: "{{ region }}"
+      region: "{{ certificate_service_region }}"
       data:
         content: "{{ lookup('file','{{ ca.x509_certificate_file }}') }}"
 
@@ -122,7 +123,7 @@
     ibm.cloudcollection.ibm_certificate_manager_import:
       certificate_manager_instance_id: "{{ cms.id }}"
       name: "{{ vpnserver.common_name }}"
-      region: "{{ region }}"
+      region: "{{ certificate_service_region }}"
       data:
         content: "{{ lookup('file','{{ vpnserver.x509_certificate_file }}') }}"
         intermediate: "{{ lookup('file','{{ ca.x509_certificate_file }}') }}"
@@ -166,7 +167,7 @@
     ibm.cloudcollection.ibm_certificate_manager_import:
       certificate_manager_instance_id: "{{ cms.id }}"
       name: "{{ vpnclient.common_name }}"
-      region: "{{ region }}"
+      region: "{{ certificate_service_region }}"
       data:
         content: "{{ lookup('file',vpnclient.x509_certificate_file) }}"
         intermediate: "{{ lookup('file','{{ ca.x509_certificate_file }}') }}"

--- a/ibmcloud-vpnserver/roles/ibmcloud-certificates/tasks/create.yml
+++ b/ibmcloud-vpnserver/roles/ibmcloud-certificates/tasks/create.yml
@@ -1,0 +1,172 @@
+
+- when: (cms is undefined) or (cms.keys() | length < 1)
+  block:
+  - name: provision certificate manager resource instance
+    ibm.cloudcollection.ibm_resource_instance:
+      name: "{{ certificate_service_name }}"
+      location: "{{ region }}"
+      service: "cloudcerts"
+      plan: "free"
+    register: resource_instance_output
+
+  - name: Save certificate manager resource instance as fact
+    set_fact:
+      cacheable: True
+      cms: "{{ resource_instance_output.resource }}"
+    when: resource_instance_output.rc==0
+
+- name: Retrieve list of certificates already deployed
+  ibm.cloudcollection.ibm_certificate_manager_certificates_info:
+    certificate_manager_instance_id: "{{cms.id}}"
+  register: cms_certificates_info
+
+- debug:
+    var: cms_certificates_info
+
+- name: Save certificate manager resource instance as fact
+  set_fact:
+    cacheable: True
+    cert_dict: "{{ cms_certificates_info.resource.certificates |
+                  items2dict(key_name='name', value_name='cert_id') }}"
+  when: cms_certificates_info.rc==0
+
+- debug:
+    var: cert_dict
+
+- when: ca.common_name not in cert_dict.keys()
+  block:
+  - name: test for private key file
+    stat:
+      path: "{{ ca.x509_key_file }}"
+    register: ca_x509_key_test
+  - name: Create private key with password protection
+    community.crypto.openssl_privatekey:
+      path: "{{ ca.x509_key_file }}"
+      passphrase: "{{ ca.passphrase }}"
+      cipher: auto
+    when: not ca_x509_key_test.stat.exists
+  - name: test for certificate file
+    stat:
+      path: "{{ ca.x509_certificate_file }}"
+    register: ca_x509_cert_test
+  - name: Create certificate signing request (CSR) for CA certificate
+    community.crypto.openssl_csr_pipe:
+      privatekey_path: "{{ ca.x509_key_file }}"
+      privatekey_passphrase: "{{ ca.passphrase }}"
+      common_name: "{{ ca.common_name }}"
+      use_common_name_for_san: false
+      basic_constraints:
+        - 'CA:TRUE'
+      basic_constraints_critical: yes
+      key_usage:
+        - keyCertSign
+      key_usage_critical: true
+    register: ca_csr
+    when: not ca_x509_cert_test.stat.exists
+
+  - name: Create self-signed CA certificate from CSR
+    community.crypto.x509_certificate:
+      path: "{{ ca.x509_certificate_file }}"
+      csr_content: "{{ ca_csr.csr }}"
+      privatekey_path: "{{ ca.x509_key_file }}"
+      privatekey_passphrase: "{{ ca.passphrase }}"
+      provider: selfsigned
+    register: ca_certificate_output
+    when: not ca_x509_cert_test.stat.exists
+
+  - name: import our CA to {{ certificate_service_name }}
+    ibm.cloudcollection.ibm_certificate_manager_import:
+      certificate_manager_instance_id: "{{ cms.id }}"
+      name: "{{ ca.common_name }}"
+      region: "{{ region }}"
+      data:
+        content: "{{ lookup('file','{{ ca.x509_certificate_file }}') }}"
+
+- when: vpnserver.common_name not in cert_dict.keys()
+  block:
+  - name: test for private key file
+    stat:
+      path: "{{ vpnserver.x509_key_file }}"
+    register: vpnserver_x509_key_test
+  - name: Create private key for new VPN Server certificate
+    community.crypto.openssl_privatekey:
+      path: "{{ vpnserver.x509_key_file }}"
+    when: not vpnserver_x509_key_test.stat.exists
+  - name: test for cert file
+    stat:
+      path: "{{vpnserver.x509_certificate_file}}"
+    register: vpnserver_cert_test
+  - name: Create certificate signing request (CSR) for new VPN server certificate
+    community.crypto.openssl_csr_pipe:
+      privatekey_path: "{{ vpnserver.x509_key_file }}"
+      common_name: "{{ vpnserver.common_name }}"
+      key_usage:
+        - digitalSignature
+        - Key Encipherment
+      extended_key_usage:
+        - TLS Web Server Authentication
+    register: csr
+    when: not vpnserver_cert_test.stat.exists
+  - name: Sign certificate with our CA
+    community.crypto.x509_certificate:
+      csr_content: "{{ csr.csr }}"
+      provider: ownca
+      path: "{{vpnserver.x509_certificate_file}}"
+      ownca_path: "{{ ca.x509_certificate_file }}"
+      ownca_privatekey_path: "{{ ca.x509_key_file }}"
+      ownca_privatekey_passphrase: "{{ ca.passphrase }}"
+      ownca_not_after: +365d  # valid for one year
+      ownca_not_before: "-1d"  # valid since yesterday
+    when: not vpnserver_cert_test.stat.exists
+  - name: import our VPN server certificate to {{ certificate_service_name }}
+    ibm.cloudcollection.ibm_certificate_manager_import:
+      certificate_manager_instance_id: "{{ cms.id }}"
+      name: "{{ vpnserver.common_name }}"
+      region: "{{ region }}"
+      data:
+        content: "{{ lookup('file','{{ vpnserver.x509_certificate_file }}') }}"
+        intermediate: "{{ lookup('file','{{ ca.x509_certificate_file }}') }}"
+        priv_key: "{{ lookup('file','{{ vpnserver.x509_key_file }}') }}"
+- when: vpnclient.common_name not in cert_dict.keys()
+  block:
+  - name: test for private key file
+    stat:
+      path: "{{ vpnclient.x509_key_file }}"
+    register: vpnclient_key_test
+  - name: Create private key for client certificate
+    community.crypto.openssl_privatekey:
+      path: "{{ vpnclient.x509_key_file }}"
+    when: not vpnclient_key_test.stat.exists
+  - name: test for cert file
+    stat:
+      path: "{{ vpnclient.x509_certificate_file }}"
+    register: vpnclient_cert_test
+  - name: Create certificate signing request (CSR) for new client certificate
+    community.crypto.openssl_csr_pipe:
+      privatekey_path: "{{ vpnclient.x509_key_file }}"
+      common_name: "{{vpnclient.common_name}}"
+      key_usage:
+        - digitalSignature
+      extended_key_usage:
+        - TLS Web Client Authentication
+    register: csr
+    when: not vpnclient_cert_test.stat.exists
+  - name: Sign client certificate with our CA
+    community.crypto.x509_certificate:
+      csr_content: "{{ csr.csr }}"
+      provider: ownca
+      path: "{{ vpnclient.x509_certificate_file}}"
+      ownca_path: "{{ ca.x509_certificate_file }}"
+      ownca_privatekey_path: "{{ ca.x509_key_file }}"
+      ownca_privatekey_passphrase: "{{ ca.passphrase }}"
+      ownca_not_after: +365d  # valid for one year
+      ownca_not_before: "-1d"  # valid since yesterday
+    when: not vpnclient_cert_test.stat.exists
+  - name: import our VPN client certificate to {{ certificate_service_name }}
+    ibm.cloudcollection.ibm_certificate_manager_import:
+      certificate_manager_instance_id: "{{ cms.id }}"
+      name: "{{ vpnclient.common_name }}"
+      region: "{{ region }}"
+      data:
+        content: "{{ lookup('file',vpnclient.x509_certificate_file) }}"
+        intermediate: "{{ lookup('file','{{ ca.x509_certificate_file }}') }}"

--- a/ibmcloud-vpnserver/roles/ibmcloud-certificates/tasks/destroy.yml
+++ b/ibmcloud-vpnserver/roles/ibmcloud-certificates/tasks/destroy.yml
@@ -4,7 +4,7 @@
     - name: destroy certificate manager resource instance
       ibm.cloudcollection.ibm_resource_instance:
         name: "{{ certificate_service_name }}"
-        location: "{{ region }}"
+        location: "{{ certificate_service_region }}"
         service: "cloudcerts"
         plan: "free"
         state: "absent"

--- a/ibmcloud-vpnserver/roles/ibmcloud-certificates/tasks/destroy.yml
+++ b/ibmcloud-vpnserver/roles/ibmcloud-certificates/tasks/destroy.yml
@@ -1,0 +1,17 @@
+
+- when: (cms is defined) and (cms.keys() | length > 0) and (destroy_certmgr is true)
+  block:
+    - name: destroy certificate manager resource instance
+      ibm.cloudcollection.ibm_resource_instance:
+        name: "{{ certificate_service_name }}"
+        location: "{{ region }}"
+        service: "cloudcerts"
+        plan: "free"
+        state: "absent"
+    - set_fact:
+        cacheable: True
+        cert_dict: {}
+    - name: Clear certificate manager fact
+      set_fact:
+        cacheable: True
+        cms: {}

--- a/ibmcloud-vpnserver/roles/ibmcloud-certificates/tasks/main.yml
+++ b/ibmcloud-vpnserver/roles/ibmcloud-certificates/tasks/main.yml
@@ -1,0 +1,5 @@
+- include: create.yml
+  when: mode == "create"
+  
+- include: destroy.yml
+  when: mode == "destroy" and destroy_certmgr is true

--- a/ibmcloud-vpnserver/roles/ibmcloud-vpc/defaults/main.yml
+++ b/ibmcloud-vpnserver/roles/ibmcloud-vpc/defaults/main.yml
@@ -1,0 +1,21 @@
+# Name for the VPC
+vpc_name: zlinux-ansible
+
+# Name for the components for the VPC created objects (VPC, subnetwork, VSI)
+zlinux-ansible:
+  subnets:
+  - name: "{{ vpc_name }}-subnet-1"
+    zone: "{{region}}-1"
+  security_group:
+    tcp:
+    - 443
+    - 80
+    - 22
+
+# If destroy_vpc is enabled then the destroy playbook will delete the subnets and the vpc
+destroy_vpc: False
+
+# Size of the created subnetwork
+total_ipv4_address_count: 256
+
+mode: "create"

--- a/ibmcloud-vpnserver/roles/ibmcloud-vpc/meta/requirements.yml
+++ b/ibmcloud-vpnserver/roles/ibmcloud-vpc/meta/requirements.yml
@@ -1,0 +1,3 @@
+collections:
+  - name: ibm.cloudcollection
+    version: 1.28.0

--- a/ibmcloud-vpnserver/roles/ibmcloud-vpc/tasks/create.yml
+++ b/ibmcloud-vpnserver/roles/ibmcloud-vpc/tasks/create.yml
@@ -1,0 +1,43 @@
+
+- when: (vpc is undefined) or (vpc.keys() | length < 1)
+  block:
+    - name: Create VPC
+      ibm.cloudcollection.ibm_is_vpc:
+        name: "{{ vpc_name }}"
+        state: available
+        id: "{{ vpc.id | default(omit) }}"
+      register: vpc_create_output
+
+    - name: Create security group rules
+      ibm.cloudcollection.ibm_is_security_group_rule:
+        state: available
+        group: "{{ vpc_create_output.resource.default_security_group }}"
+        direction: inbound
+        remote: 0.0.0.0/0
+        tcp:
+        - port_max: "{{ item }}"
+          port_min: "{{ item }}"
+      loop: "{{ lookup('vars',vpc_name).security_group.tcp }}"
+
+    - name: Save VPC as fact
+      set_fact:
+        cacheable: True
+        vpc: "{{ vpc_create_output.resource }}"
+
+- when: (subnet_dict is undefined) or (subnet_dict.keys() | length < 1)
+  name: Create VPC Subnets
+  ibm.cloudcollection.ibm_is_subnet:
+    name: "{{ item.name }}"
+    state: available
+    vpc: "{{ vpc.id }}"
+    total_ipv4_address_count: "{{ total_ipv4_address_count }}"
+    zone: "{{ item.zone }}"
+  register: subnet_create_output
+  loop: "{{ lookup('vars',vpc_name).subnets }}"
+
+- name: Save VPC subnets as fact
+  set_fact:
+    cacheable: True
+    subnet_dict: "{{ subnet_dict | default({}) | combine ({item.resource.zone: item.resource.id }) }}"
+  with_items: "{{ subnet_create_output.results }}"
+  when: subnet_create_output.changed is true

--- a/ibmcloud-vpnserver/roles/ibmcloud-vpc/tasks/destroy.yml
+++ b/ibmcloud-vpnserver/roles/ibmcloud-vpc/tasks/destroy.yml
@@ -1,0 +1,23 @@
+- name: Remove VPC Subnets
+  when: (subnet_dict is defined) and (subnet_dict.keys() | length > 0) and (destroy_vpc is true)
+  block:  
+    - ibm.cloudcollection.ibm_is_subnet:
+        state: absent
+        id: "{{ item.value }}"
+      loop: "{{ subnet_dict|dict2items }}"
+      
+    - set_fact:
+        cacheable: True
+        subnet_dict: {}
+
+- name: Remove VPC
+  when: (vpc is defined) and (vpc.keys() | length > 0) and (destroy_vpc is true)
+  block:
+    - ibm.cloudcollection.ibm_is_vpc:
+        state: absent
+        id: "{{ vpc.id }}"
+
+    - name: Clear VPC fact
+      set_fact:
+        cacheable: True
+        vpc: {}

--- a/ibmcloud-vpnserver/roles/ibmcloud-vpc/tasks/main.yml
+++ b/ibmcloud-vpnserver/roles/ibmcloud-vpc/tasks/main.yml
@@ -1,0 +1,5 @@
+- include: create.yml
+  when: mode == "create"
+  
+- include: destroy.yml
+  when: mode == "destroy" and destroy_vpc is true

--- a/ibmcloud-vpnserver/roles/ibmcloud-vpn-restapi/defaults/main.yml
+++ b/ibmcloud-vpnserver/roles/ibmcloud-vpn-restapi/defaults/main.yml
@@ -1,0 +1,4 @@
+
+ibmcloud_api_version: "2022-02-07"
+destroy_vpn: False
+ovpn_config_file: "ibmcloud.ovpn"

--- a/ibmcloud-vpnserver/roles/ibmcloud-vpn-restapi/defaults/main.yml
+++ b/ibmcloud-vpnserver/roles/ibmcloud-vpn-restapi/defaults/main.yml
@@ -1,4 +1,6 @@
-
+ibmcloud_iam_api_endpoint: "https://iam.cloud.ibm.com"
 ibmcloud_api_version: "2022-02-07"
 destroy_vpn: False
 ovpn_config_file: "ibmcloud.ovpn"
+
+certificate_service_region: "{{region}}"

--- a/ibmcloud-vpnserver/roles/ibmcloud-vpn-restapi/meta/requirements.yml
+++ b/ibmcloud-vpnserver/roles/ibmcloud-vpn-restapi/meta/requirements.yml
@@ -1,0 +1,3 @@
+collections:
+  - name: ibm.cloudcollection
+    version: 1.37.1

--- a/ibmcloud-vpnserver/roles/ibmcloud-vpn-restapi/tasks/create.yml
+++ b/ibmcloud-vpnserver/roles/ibmcloud-vpn-restapi/tasks/create.yml
@@ -4,6 +4,7 @@
     - name: Retrieve list of certificates already deployed
       ibm.cloudcollection.ibm_certificate_manager_certificates_info:
         certificate_manager_instance_id: "{{cms.id}}"
+        region: "{{ certificate_service_region }}"
       register: cms_certificates_info
 
     - name: Save certificate manager resource instance as fact

--- a/ibmcloud-vpnserver/roles/ibmcloud-vpn-restapi/tasks/create.yml
+++ b/ibmcloud-vpnserver/roles/ibmcloud-vpn-restapi/tasks/create.yml
@@ -1,0 +1,85 @@
+
+- when: (vpn_server is undefined) or (vpn_server.keys() | length < 1)
+  block:
+    - name: Retrieve list of certificates already deployed
+      ibm.cloudcollection.ibm_certificate_manager_certificates_info:
+        certificate_manager_instance_id: "{{cms.id}}"
+      register: cms_certificates_info
+
+    - name: Save certificate manager resource instance as fact
+      set_fact:
+        cacheable: True
+        cert_dict: "{{ cms_certificates_info.resource.certificates |
+                      items2dict(key_name='name', value_name='cert_id') }}"
+      when: cms_certificates_info.rc==0
+    - name: "Retrieve IBM Cloud vpc address prefixes"
+      ibm.cloudcollection.ibm_is_vpc_address_prefixes_info:
+        vpc: "{{vpc.id}}"
+      register: get_addresses_output
+    - debug:
+        var: get_addresses_output
+    - name: create vpn gateway
+      uri:
+        method: POST
+        url: "{{ ansible_env.IBMCLOUD_IS_NG_API_ENDPOINT | default('https://'+region+'.iaas.cloud.ibm.com') }}/v1/vpn_servers?version={{ibmcloud_api_version}}&generation=2&maturity=beta" 
+        headers: 
+          Authorization: "Bearer {{ IAM_TOKEN }} " 
+          Content-Type: "application/json" 
+          accept: "application/json" 
+        body_format: json
+        body:
+          certificate:
+            crn: "{{cert_dict[vpnserver.common_name]}}"
+          client_authentication:
+            -  method: "certificate"
+               client_ca:
+                 crn: "{{cert_dict[vpnclient.common_name]}}"
+          client_idle_timeout: 600
+          client_ip_pool: "{{ lookup('vars',vpc_name).vpn.client_ip_pool }}"
+          enable_split_tunneling: true
+          name: "{{ lookup('vars',vpc_name).vpn.name }}"
+          port: 443
+          protocol: "tcp"
+          resource_group:
+            id: "{{ vpc.resource_group}}"
+          subnets:
+            - id: "{{ subnet_dict[lookup('vars',vpc_name).vpn.zone] }}" 
+        status_code:
+          - 200
+          - 201
+      register: vpn_server_create_response
+    - name: Retrieve vpn gateway information
+      uri:
+        method: GET
+        url: "{{ ansible_env.IBMCLOUD_IS_NG_API_ENDPOINT | default('https://'+region+'.iaas.cloud.ibm.com') }}/v1/vpn_servers/{{vpn_server_create_response.json.id }}?version={{ibmcloud_api_version}}&generation=2&maturity=beta" 
+        headers: 
+          Authorization: "Bearer {{ IAM_TOKEN }} " 
+          Content-Type: "application/json" 
+          accept: "application/json" 
+      register: vpn_server_output
+    - name: Set address routes for the VPC into the VPN server
+      uri:
+        method: POST
+        url: "{{ ansible_env.IBMCLOUD_IS_NG_API_ENDPOINT | default('https://'+region+'.iaas.cloud.ibm.com') }}/v1/vpn_servers/{{vpn_server_create_response.json.id }}/routes?version={{ibmcloud_api_version}}&generation=2&maturity=beta" 
+        headers: 
+          Authorization: "Bearer {{ IAM_TOKEN }} " 
+          Content-Type: "application/json" 
+          accept: "application/json"  
+        body_format: json
+        body:
+          name: "{{item.name}}"
+          destination: "{{item.cidr}}"
+          action: "translate"
+        status_code:
+        - 200
+        - 201
+      loop: "{{get_addresses_output.resource.address_prefixes}}"
+    - name: Set vpn gateway information as fact
+      set_fact:
+        cacheable: True
+        vpn_server: "{{vpn_server_output.json}}"
+
+- name: "Create the {{ovpn_config_file}} OpenVPN profile"
+  template:
+    src: ovpn.j2
+    dest: "{{ovpn_config_file}}"

--- a/ibmcloud-vpnserver/roles/ibmcloud-vpn-restapi/tasks/destroy.yml
+++ b/ibmcloud-vpnserver/roles/ibmcloud-vpn-restapi/tasks/destroy.yml
@@ -1,0 +1,17 @@
+- when: (vpn_server is defined) and (vpn_server.keys() | length > 0) and (destroy_vpn is true)
+  block:    
+    - name: delete vpn gateway 
+      uri:
+        method: DELETE
+        url: "{{ ansible_env.IBMCLOUD_IS_NG_API_ENDPOINT | default('https://'+region+'.iaas.cloud.ibm.com') }}/v1/vpn_servers/{{vpn_server.id}}?version={{ibmcloud_api_version}}&generation=2&maturity=beta" 
+        headers: 
+          Authorization: "Bearer {{ IAM_TOKEN }} " 
+          Content-Type: "application/json" 
+          accept: "application/json" 
+        status_code:
+        - 200
+        - 202
+    - name: Clear vpn fact
+      set_fact:
+        cacheable: True
+        vpn_server: {}

--- a/ibmcloud-vpnserver/roles/ibmcloud-vpn-restapi/tasks/main.yml
+++ b/ibmcloud-vpnserver/roles/ibmcloud-vpn-restapi/tasks/main.yml
@@ -1,0 +1,22 @@
+- name: "Get an IAM token"
+  uri:
+    method: POST
+    url: "{{ansible_env.IBMCLOUD_IAM_API_ENDPOINT | default ('https://iam.cloud.ibm.com')}}/identity/token"
+    body_format: json
+    body: "grant_type=urn:ibm:params:oauth:grant-type:apikey&apikey={{ ansible_env.IC_API_KEY }}"
+    headers:
+      Content-Type: "application/x-www-form-urlencoded"
+  register: iam_resp
+
+- name: "Set IAM_TOKEN"
+  set_fact:
+    IAM_TOKEN: "{{ iam_resp['json']['access_token'] }}"
+
+- debug:
+    var: IAM_TOKEN
+
+- include: create.yml
+  when: mode == "create"
+
+- include: destroy.yml
+  when: mode == "destroy" and destroy_vpn is true

--- a/ibmcloud-vpnserver/roles/ibmcloud-vpn-restapi/tasks/main.yml
+++ b/ibmcloud-vpnserver/roles/ibmcloud-vpn-restapi/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: "Get an IAM token"
   uri:
     method: POST
-    url: "{{ansible_env.IBMCLOUD_IAM_API_ENDPOINT | default ('https://iam.cloud.ibm.com')}}/identity/token"
+    url: "{{ibmcloud_iam_api_endpoint}}/identity/token"
     body_format: json
     body: "grant_type=urn:ibm:params:oauth:grant-type:apikey&apikey={{ ansible_env.IC_API_KEY }}"
     headers:
@@ -11,9 +11,6 @@
 - name: "Set IAM_TOKEN"
   set_fact:
     IAM_TOKEN: "{{ iam_resp['json']['access_token'] }}"
-
-- debug:
-    var: IAM_TOKEN
 
 - include: create.yml
   when: mode == "create"

--- a/ibmcloud-vpnserver/roles/ibmcloud-vpn-restapi/templates/ovpn.j2
+++ b/ibmcloud-vpnserver/roles/ibmcloud-vpn-restapi/templates/ovpn.j2
@@ -1,0 +1,26 @@
+client
+dev tun
+proto {{vpn_server.protocol}}
+port {{vpn_server.port}}
+remote {{vpn_server.hostname}}
+resolv-retry infinite
+remote-cert-tls server
+nobind
+
+auth SHA256
+cipher AES-256-GCM
+verb 3
+
+<ca>
+{{lookup('file', ca.x509_certificate_file) }}
+</ca>
+
+<cert>
+{{lookup('file', vpnclient.x509_certificate_file) }}
+</cert>
+
+<key>
+{{lookup('file', vpnclient.x509_key_file) }}
+</key>
+
+reneg-sec 0


### PR DESCRIPTION
This is a sample playbook for generating a client-to-site VPN server on IBM Cloud. This creates a single subnetwork VPC
and deploys a client-to-site VPN server into it. This playbook produces certificates for use by the VPN server and client.
It does not establish separate, by userid, login credentials, so anyone with the resulting ovpn file will be able to
establish a VPN to the environment. Finally this playbook uses the IBM Cloud API to deploy the client-to-site VPN server.
Once the ibm.cloudcollection ansible collection has been enriched to deploy the VPN server, it should be used instead of this sample.