### PR TITLE
Add s390x version of postgresql cluster on VPC

### DIFF
--- a/terraform-hpvs/postgresql-cluster/README.md
+++ b/terraform-hpvs/postgresql-cluster/README.md
@@ -1,0 +1,65 @@
+## Postgres - Running s390x version of Postgres
+
+This deploys a simple [postgres](https://hub.docker.com/r/s390x/postgres/) cluster on [IBM Cloud Hyper Protect Virtual Server for IBM Cloud VPC](https://cloud.ibm.com/docs/vpc?topic=vpc-about-se). This will create a master instance and two slave instances. The postgres cluster only implements the function of master-slave backup. Slave instance backed up master instance.
+
+### Prerequisite
+
+Prepare your environment according to [these steps](https://github.com/ibm-hyper-protect/linuxone-vsi-automation-samples/blob/master/terraform-hpvs/README.md)
+
+### Settings
+
+Set the following environment variables:
+
+```text
+export IBMCLOUD_API_ENDPOINT=https://test.cloud.ibm.com
+export IBMCLOUD_IAM_API_ENDPOINT=https://iam.test.cloud.ibm.com
+export IBMCLOUD_IS_NG_API_ENDPOINT=https://us-south-*.cloud.ibm.com/v1 #set the value
+export IBMCLOUD_IS_API_ENDPOINT=https://us-south-*.cloud.ibm.com #set the value
+```
+
+Set the default vaule of variables.tf:
+
+```text
+"ibmcloud_api_key"
+"region"
+"zone_master"
+"zone_slave_1"
+"zone_slave_2"
+"logdna_ingestion_key"
+"logdna_ingestion_hostname"
+"prefix"
+"profile" 
+"ssh_public_key"
+```
+
+Create a new folder `compose_slave`:
+
+```text
+mkdir compose_slave
+```
+
+### Run the Example
+
+- Initialize terraform:
+
+```bash
+terraform init
+```
+
+- Deploy the postgres container
+
+```bash
+terraform apply
+```
+
+This will create a master instance and two slave instances of Hyper Protect Virtual Server for VPC instances in given regions and prints the public IP address of the VSI as an output to the console. You could use clients `psql` to connect to the database.
+
+```bash
+psql -h ${vsi_ip} -p 5432 -U postgres
+```
+
+- Destroy the created resources:
+
+```bash
+terraform destroy
+```

--- a/terraform-hpvs/postgresql-cluster/compose_master/docker-compose.yml
+++ b/terraform-hpvs/postgresql-cluster/compose_master/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  postgresql:
+    image: docker.io/library/postgres:12@sha256:d5433064852277f3187a591e02780d377c253f69bfbe3ca66c4cf3d58be83996
+    ports:
+      - "5432:5432"
+    restart: always
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
+    command:
+      - /bin/bash
+      - -c
+      - |
+        docker-entrypoint.sh postgres &
+        sleep 2
+        su postgres -c "psql -c \"CREATE ROLE replica WITH REPLICATION PASSWORD 'testpassword' LOGIN;\""
+        su postgres -c "psql -c 'create database database_for_demo;'"
+        su postgres -c "psql -c '\c database_for_demo;' -c 'CREATE TABLE TABLE_FOR_DEMO(ID INT PRIMARY KEY NOT NULL, NUMBER INT NOT NULL);'"
+        su postgres -c "psql -c '\c database_for_demo;' -c 'INSERT INTO TABLE_FOR_DEMO (ID,NUMBER) VALUES (1, 1234567);'"
+        su postgres -c "psql -c '\c database_for_demo;' -c 'INSERT INTO TABLE_FOR_DEMO (ID,NUMBER) VALUES (2, 7654321);'"
+        sed -i '$$a host replication replica all trust' /var/lib/postgresql/data/pg_hba.conf
+        kill %1
+        wait
+        docker-entrypoint.sh postgres

--- a/terraform-hpvs/postgresql-cluster/terraform.tf
+++ b/terraform-hpvs/postgresql-cluster/terraform.tf
@@ -1,0 +1,256 @@
+terraform {
+  required_providers {
+    ibm = {
+      source  = "IBM-Cloud/ibm"
+      version = ">= 1.37.1"
+    }
+    hpcr = {
+      source  = "ibm-hyper-protect/hpcr"
+      version = ">= 0.1.1"
+    }
+    local = {
+      source = "hashicorp/local"
+      version = "2.2.3"
+    }
+    time = {
+      source = "hashicorp/time"
+      version = "0.9.0"
+    }
+  }
+}
+# make sure to target the correct region and zone
+provider "ibm" {
+  ibmcloud_api_key = var.ibmcloud_api_key
+  region = var.region
+}
+locals {
+  # some reusable tags that identify the resources created by his sample
+  tags = ["zvsi", "sample", var.prefix]
+}
+# the VPC
+resource "ibm_is_vpc" "postgres_vpc" {
+  name = format("%s-vpc", var.prefix)
+  tags = local.tags
+}
+# the security group
+resource "ibm_is_security_group" "postgres_security_group" {
+  name = format("%s-security-group", var.prefix)
+  vpc  = ibm_is_vpc.postgres_vpc.id
+  tags = local.tags
+}
+resource "ibm_is_security_group_rule" "postgres_outbound" {
+  group     = ibm_is_security_group.postgres_security_group.id
+  direction = "outbound"
+  remote    = "0.0.0.0/0"
+}
+# Rule that allows inbound traffic to the postgres server
+# to connect to the logDNA instance as well as to docker to pull the image
+resource "ibm_is_security_group_rule" "postgres_inbound" {
+  group     = ibm_is_security_group.postgres_security_group.id
+  direction = "inbound"
+  remote    = "0.0.0.0/0"
+   tcp {
+      port_min = 5432
+      port_max = 5432
+    }
+}
+resource "ibm_is_ssh_key" "postgres_sshkey" {
+  name       = "key-terr"
+  public_key = "${file(var.ssh_public_key)}"
+  tags       = local.tags
+}
+# Locate the latest hyper protect image
+data "ibm_is_images" "hyper_protect_images" {
+  visibility = "public"
+  status     = "available"
+}
+locals {
+  # Filter the available images down to the hyper protect one
+  hyper_protect_image = one(toset([for each in data.ibm_is_images.hyper_protect_images.images : each if each.os == "hyper-protect-1-0-s390x" && each.architecture == "s390x"]))
+}
+
+########## master node
+# the subnet
+resource "ibm_is_subnet" "postgres_subnet_master" {
+  name                     = format("%s-master-subnet", var.prefix)
+  vpc                      = ibm_is_vpc.postgres_vpc.id
+  total_ipv4_address_count = 256
+  zone                     = "${var.region}-${var.zone_master}"
+  tags                     = local.tags
+}
+resource "hpcr_tgz" "contract_master" {
+  folder = "compose_master"
+}
+locals {
+  # contract in clear text
+  contract_master = yamlencode({
+    "env" : {
+      "type" : "env",
+      "logging" : {
+        "logDNA" : {
+          "hostname" : var.logdna_ingestion_hostname,
+          "ingestionKey" : var.logdna_ingestion_key,
+          "port" : 6514,
+        }
+      },
+    },
+    "workload" : {
+      "type" : "workload",
+      "compose" : {
+        "archive" : hpcr_tgz.contract_master.rendered
+      }
+    }
+  })
+}
+resource "hpcr_contract_encrypted" "contract_master" {
+  contract = local.contract_master
+}
+# construct the VSI
+resource "ibm_is_instance" "postgres_vsi_master" {
+  name    = format("%s-master-vsi", var.prefix)
+  image   = local.hyper_protect_image.id
+  profile = var.profile
+  keys    = ["${ibm_is_ssh_key.postgres_sshkey.id}"]
+  vpc     = ibm_is_vpc.postgres_vpc.id
+  tags    = local.tags
+  zone    = "${var.region}-${var.zone_master}"
+  user_data = hpcr_contract_encrypted.contract_master.rendered
+  primary_network_interface {
+    name            = "eth0"
+    subnet          = ibm_is_subnet.postgres_subnet_master.id
+    security_groups = [ibm_is_security_group.postgres_security_group.id]
+  }
+}
+resource "ibm_is_floating_ip" "postgres_fip_master" {
+  name    = format("%s-master-vsi", var.prefix)
+  target  = ibm_is_instance.postgres_vsi_master.primary_network_interface[0].id  
+}
+resource "local_file" "slave_docker_compose" {
+    content  = <<-EOT
+    services:
+      postgresql:
+        image: docker.io/library/postgres:12@sha256:d5433064852277f3187a591e02780d377c253f69bfbe3ca66c4cf3d58be83996
+        ports:
+          - "5432:5432"
+        command:
+          - /bin/bash
+          - -c
+          - |
+            docker-entrypoint.sh postgres &
+            sleep 2
+            su - postgres -c "rm -r /var/lib/postgresql/data/*"
+            su - postgres -c "pg_basebackup -h ${ibm_is_floating_ip.postgres_fip_master.address} -p 5432 -U replica -D /var/lib/postgresql/data/ -Fp -Xs -R"
+            wait
+            kill %1
+            wait
+            docker-entrypoint.sh postgres
+        environment:
+          - POSTGRES_HOST_AUTH_METHOD=trust
+    EOT
+    filename = "./compose_slave/docker-compose.yml"
+}
+
+########## slave node
+resource "hpcr_tgz" "contract_slave" {
+  folder = "compose_slave"
+  depends_on = [local_file.slave_docker_compose]
+}
+locals {
+  # contract in clear text
+  contract_slave = yamlencode({
+    "env" : {
+      "type" : "env",
+      "logging" : {
+        "logDNA" : {
+          "hostname" : var.logdna_ingestion_hostname,
+          "ingestionKey" : var.logdna_ingestion_key,
+          "port" : 6514,
+        }
+      },
+    },
+    "workload" : {
+      "type" : "workload",
+      "compose" : {
+        "archive" : hpcr_tgz.contract_slave.rendered
+      }
+    }
+  })
+}
+resource "hpcr_contract_encrypted" "contract_slave" {
+  contract = local.contract_slave
+}
+
+##### slave_1 node
+# the subnet
+resource "ibm_is_subnet" "postgres_subnet_slave_1" {
+  name                     = format("%s-slave-subnet-%s", var.prefix, var.zone_slave_1)
+  vpc                      = ibm_is_vpc.postgres_vpc.id
+  total_ipv4_address_count = 256
+  zone                     = "${var.region}-${var.zone_slave_1}"
+  tags                     = local.tags
+}
+# construct the VSI
+resource "ibm_is_instance" "postgres_vsi_slave_1" {
+  name    = format("%s-slave-vsi-%s", var.prefix, var.zone_slave_1)
+  image   = local.hyper_protect_image.id
+  profile = var.profile
+  keys    = ["${ibm_is_ssh_key.postgres_sshkey.id}"]
+  vpc     = ibm_is_vpc.postgres_vpc.id
+  tags    = local.tags
+  zone    = "${var.region}-${var.zone_slave_1}"
+  user_data = hpcr_contract_encrypted.contract_slave.rendered
+  primary_network_interface {
+    name            = "eth0"
+    subnet          = ibm_is_subnet.postgres_subnet_slave_1.id
+    security_groups = [ibm_is_security_group.postgres_security_group.id]
+  }
+}
+resource "ibm_is_floating_ip" "postgres_fip_slave_1" {
+  name    = format("%s-slave-vsi-%s", var.prefix, var.zone_slave_1)
+  target  = ibm_is_instance.postgres_vsi_slave_1.primary_network_interface[0].id  
+}
+
+##### slave_2 node
+resource "time_sleep" "wait_60_seconds" {
+  depends_on = [ibm_is_floating_ip.postgres_fip_slave_1]
+  create_duration = "60s"
+}
+resource "ibm_is_subnet" "postgres_subnet_slave_2" {
+  name                     = format("%s-slave-subnet-%s", var.prefix, var.zone_slave_2)
+  vpc                      = ibm_is_vpc.postgres_vpc.id
+  total_ipv4_address_count = 256
+  zone                     = "${var.region}-${var.zone_slave_2}"
+  tags                     = local.tags
+}
+resource "ibm_is_instance" "postgres_vsi_slave_2" {
+  name    = format("%s-slave-vsi-%s", var.prefix, var.zone_slave_2)
+  image   = local.hyper_protect_image.id
+  profile = var.profile
+  keys    = ["${ibm_is_ssh_key.postgres_sshkey.id}"]
+  vpc     = ibm_is_vpc.postgres_vpc.id
+  tags    = local.tags
+  zone    = "${var.region}-${var.zone_slave_2}"
+  user_data = hpcr_contract_encrypted.contract_slave.rendered
+  primary_network_interface {
+    name            = "eth0"
+    subnet          = ibm_is_subnet.postgres_subnet_slave_2.id
+    security_groups = [ibm_is_security_group.postgres_security_group.id]
+  }
+  depends_on = [time_sleep.wait_60_seconds]
+}
+resource "ibm_is_floating_ip" "postgres_fip_slave_2" {
+  name    = format("%s-slave-vsi-%s", var.prefix, var.zone_slave_2)
+  target  = ibm_is_instance.postgres_vsi_slave_2.primary_network_interface[0].id  
+}
+output "sshcommand_master"{
+  value = resource.ibm_is_floating_ip.postgres_fip_master.address
+  description = "The public IP address of master the VSI on zone1"
+}
+output "sshcommand_slave_1"{
+  value = resource.ibm_is_floating_ip.postgres_fip_slave_1.address
+  description = "The public IP address of the slave VSI on zone2"
+}
+output "sshcommand_slave_2"{
+  value = resource.ibm_is_floating_ip.postgres_fip_slave_2.address
+  description = "The public IP address of the slave VSI on zone3"
+}

--- a/terraform-hpvs/postgresql-cluster/variables.tf
+++ b/terraform-hpvs/postgresql-cluster/variables.tf
@@ -1,37 +1,56 @@
 variable "ibmcloud_api_key" {
   description = "Enter your IBM Cloud API Key, you can get your IBM Cloud API key using: https://cloud.ibm.com/iam#/apikeys"
-  default = "********"
+  default = "*********"
 }
+
 variable "region" {
   type        = string
   description = "Region to deploy to, e.g. eu-gb."
   default = "us-south"
 }
-variable "zone" {
+
+variable "zone_master" {
   type        = string
-  description = "Zone to deploy to, e.g. 2."
+  description = "Zone to deploy master to, e.g. 1."
+  default = "1"
+}
+
+variable "zone_slave_1" {
+  type        = string
+  description = "Zone to deploy slave_1 to, e.g. 2."
   default = "2"
 }
+
+variable "zone_slave_2" {
+  type        = string
+  description = "Zone to deploy slave_2 to, e.g. 3."
+  default = "3"
+}
+
 variable "logdna_ingestion_key" {
   type        = string
   description = "Ingestion key for IBM Log Analysis instance. This can be obtained from 'Linux/Ubuntu' section of 'Logging resource' tab of IBM Log Analysis instance"
   default = "******"
 }
+
 variable "logdna_ingestion_hostname" {
   type        = string
   description = "rsyslog endpoint of IBM Log Analysis instance. Don't include the port. Example: syslog-a.<region>.logging.cloud.ibm.com"
   default = "syslog-***.logging.cloud.ibm.com"
 }
+
 variable "prefix" {
   type        = string
   description = "Prefix for all generated resources. Make sure to have a custom image with that name."
   default     = "zvsi-sample-postgres"
 }
+
 variable "profile" {
   type        = string
   description = "Profile used for the VSI, this is a profile for normal zlinux VSI , the profile in the format Xz2-YxZ, e.g. bz2-1x4."
   default     = "bz2e-1x4"
 }
+
 variable "ssh_public_key" {
   default = "~/.ssh/id_rsa.pub"
 }


### PR DESCRIPTION
Add s390x version of postgresql cluster on VPC. This will create a master instance and two slave instances. The postgresql cluster only implements the function of master-slave backup. The slave instance backed up the master instance.