### PR TITLE
Put a dependency on the encryption public key

### DIFF
--- a/terraform-hpvs/log-encryption/terraform.tf
+++ b/terraform-hpvs/log-encryption/terraform.tf
@@ -95,6 +95,7 @@ resource "ibm_is_subnet_public_gateway_attachment" "log_encryption_gateway_attac
 # to be mounted into containers, environment files etc. This is why all of these files get bundled in a tgz file (base64 encoded)
 resource "hpcr_tgz" "contract" {
   folder = "compose"
+  depends_on = [local_file.log_encryption_logging_public_key]
 }
 
 locals {


### PR DESCRIPTION
A dependency on the logging encryption public key is necessary to prevent the compose folder from being archived prior to the public key having been created, which causes the encryption from example.sh to fail within the container.

Signed-off-by: Barry Silliman [silliman@us.ibm.com](mailto:silliman@us.ibm.com)