### PR TITLE
A workaround to pick one of multiple VSI images

### DIFF
--- a/terraform-hpvs/hello-world/terraform.tf
+++ b/terraform-hpvs/hello-world/terraform.tf
@@ -125,7 +125,7 @@ data "ibm_is_images" "hyper_protect_images" {
 
 locals {
   # filter the available images down to the hyper protect one
-  hyper_protect_image = one(toset([for each in data.ibm_is_images.hyper_protect_images.images : each if each.os == "hyper-protect-1-0-s390x" && each.architecture == "s390x"]))
+  hyper_protect_image = [for each in data.ibm_is_images.hyper_protect_images.images : each if each.os == "hyper-protect-1-0-s390x" && each.architecture == "s390x"][0]
 }
 
 # In this step we encrypt the fields of the contract and sign the env and workload field. The certificate to execute the 

--- a/terraform-hpvs/log-encryption/terraform.tf
+++ b/terraform-hpvs/log-encryption/terraform.tf
@@ -142,7 +142,7 @@ data "ibm_is_images" "hyper_protect_images" {
 
 locals {
   # filter the available images down to the hyper protect one
-  hyper_protect_image = one(toset([for each in data.ibm_is_images.hyper_protect_images.images : each if each.os == "hyper-protect-1-0-s390x" && each.architecture == "s390x"]))
+  hyper_protect_image = [for each in data.ibm_is_images.hyper_protect_images.images : each if each.os == "hyper-protect-1-0-s390x" && each.architecture == "s390x"][0]
 }
 
 # In this step we encrypt the fields of the contract and sign the env and workload field. The certificate to execute the 

--- a/terraform-hpvs/mongodb/terraform.tf
+++ b/terraform-hpvs/mongodb/terraform.tf
@@ -126,7 +126,7 @@ data "ibm_is_images" "hyper_protect_images" {
 
 locals {
   # Filter the available images down to the hyper protect one
-  hyper_protect_image = one(toset([for each in data.ibm_is_images.hyper_protect_images.images : each if each.os == "hyper-protect-1-0-s390x" && each.architecture == "s390x"]))
+  hyper_protect_image = [for each in data.ibm_is_images.hyper_protect_images.images : each if each.os == "hyper-protect-1-0-s390x" && each.architecture == "s390x"][0]
 }
 
 # In this step, we encrypt the fields of the contract and sign the env and workload field.

--- a/terraform-hpvs/nginx-hello/cloud/terraform.tf
+++ b/terraform-hpvs/nginx-hello/cloud/terraform.tf
@@ -93,7 +93,7 @@ data "ibm_is_images" "hyper_protect_images" {
 
 locals {
   # filter the available images down to the hyper protect one
-  hyper_protect_image = one(toset([for each in data.ibm_is_images.hyper_protect_images.images : each if each.os == "hyper-protect-1-0-s390x" && each.architecture == "s390x"]))
+  hyper_protect_image = [for each in data.ibm_is_images.hyper_protect_images.images : each if each.os == "hyper-protect-1-0-s390x" && each.architecture == "s390x"][0]
 }
 
 # construct the VSI

--- a/terraform-hpvs/postgresql-cluster/terraform.tf
+++ b/terraform-hpvs/postgresql-cluster/terraform.tf
@@ -66,7 +66,7 @@ data "ibm_is_images" "hyper_protect_images" {
 }
 locals {
   # Filter the available images down to the hyper protect one
-  hyper_protect_image = one(toset([for each in data.ibm_is_images.hyper_protect_images.images : each if each.os == "hyper-protect-1-0-s390x" && each.architecture == "s390x"]))
+  hyper_protect_image = [for each in data.ibm_is_images.hyper_protect_images.images : each if each.os == "hyper-protect-1-0-s390x" && each.architecture == "s390x"][0]
 }
 
 ########## master node

--- a/terraform-hpvs/postgresql/terraform.tf
+++ b/terraform-hpvs/postgresql/terraform.tf
@@ -91,7 +91,7 @@ data "ibm_is_images" "hyper_protect_images" {
 }
 locals {
   # Filter the available images down to the hyper protect one
-  hyper_protect_image = one(toset([for each in data.ibm_is_images.hyper_protect_images.images : each if each.os == "hyper-protect-1-0-s390x" && each.architecture == "s390x"]))
+  hyper_protect_image = [for each in data.ibm_is_images.hyper_protect_images.images : each if each.os == "hyper-protect-1-0-s390x" && each.architecture == "s390x"][0]
 }
 resource "hpcr_contract_encrypted" "contract" {
   contract = local.contract


### PR DESCRIPTION
This is a workaround to avoid an error when there are multiple VSI images.