### PR TITLE
update: samples to use a semantic versioning approach to select the HPCR base image

### DIFF
--- a/terraform-hpvs/hello-world/variables.tf
+++ b/terraform-hpvs/hello-world/variables.tf
@@ -3,19 +3,19 @@ variable "ibmcloud_api_key" {
                   Enter your IBM Cloud API Key, you can get your IBM Cloud API key using:
                    https://cloud.ibm.com/iam#/apikeys
                 DESC
-  sensitive  = true
+  sensitive   = true
 }
 
 variable "region" {
   type        = string
   description = "Region to deploy to, e.g. eu-gb"
 
-   validation {
-    condition     = ( var.region == "eu-gb"  ||
-                      var.region == "br-sao" ||
-                      var.region == "ca-tor" ||
-                      var.region == "jp-tok" ||
-                      var.region == "us-east" )
+  validation {
+    condition = (var.region == "eu-gb" ||
+      var.region == "br-sao" ||
+      var.region == "ca-tor" ||
+      var.region == "jp-tok" ||
+    var.region == "us-east")
     error_message = "Value of region must be one of eu-gb/br-sao/ca-tor/jp-tok/us-east."
   }
 }
@@ -26,9 +26,9 @@ variable "zone" {
   description = "Zone to deploy to, e.g. 2."
 
   validation {
-    condition     = ( var.zone == "1" ||
-                      var.zone == "2" ||
-                      var.zone == "3")
+    condition = (var.zone == "1" ||
+      var.zone == "2" ||
+    var.zone == "3")
     error_message = "Value of zone must be one of 1/2/3."
   }
 }

--- a/terraform-hpvs/log-encryption/terraform.tf
+++ b/terraform-hpvs/log-encryption/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     hpcr = {
       source  = "ibm-hyper-protect/hpcr"
-      version = ">= 0.1.1"
+      version = ">= 0.1.4"
     }
 
     tls = {
@@ -94,7 +94,7 @@ resource "ibm_is_subnet_public_gateway_attachment" "log_encryption_gateway_attac
 # archive of the folder containing docker-compose file. This folder could create additional resources such as files 
 # to be mounted into containers, environment files etc. This is why all of these files get bundled in a tgz file (base64 encoded)
 resource "hpcr_tgz" "contract" {
-  folder = "compose"
+  folder     = "compose"
   depends_on = [local_file.log_encryption_logging_public_key]
 }
 
@@ -133,16 +133,15 @@ resource "ibm_is_ssh_key" "log_encryption_sshkey" {
   tags       = local.tags
 }
 
-# locate the latest hyper protect image
+# locate all public image
 data "ibm_is_images" "hyper_protect_images" {
   visibility = "public"
   status     = "available"
-
 }
 
-locals {
-  # filter the available images down to the hyper protect one
-  hyper_protect_image = [for each in data.ibm_is_images.hyper_protect_images.images : each if each.os == "hyper-protect-1-0-s390x" && each.architecture == "s390x"][0]
+# locate the latest hyper protect image
+data "hpcr_image" "hyper_protect_image" {
+  images = jsonencode(data.ibm_is_images.hyper_protect_images.images)
 }
 
 # In this step we encrypt the fields of the contract and sign the env and workload field. The certificate to execute the 
@@ -155,7 +154,7 @@ resource "hpcr_contract_encrypted" "contract" {
 # construct the VSI
 resource "ibm_is_instance" "log_encryption_vsi" {
   name    = format("%s-vsi", var.prefix)
-  image   = local.hyper_protect_image.id
+  image   = data.hpcr_image.hyper_protect_image.image
   profile = var.profile
   keys    = [ibm_is_ssh_key.log_encryption_sshkey.id]
   vpc     = ibm_is_vpc.log_encryption_vpc.id

--- a/terraform-hpvs/mongodb/variables.tf
+++ b/terraform-hpvs/mongodb/variables.tf
@@ -9,11 +9,11 @@ variable "region" {
   type        = string
   description = "Region to deploy to, e.g. eu-gb"
 
-   validation {
-    condition     = ( var.region == "eu-gb"  ||
-                      var.region == "br-sao" ||
-                      var.region == "ca-tor" ||
-                      var.region == "jp-tok" )
+  validation {
+    condition = (var.region == "eu-gb" ||
+      var.region == "br-sao" ||
+      var.region == "ca-tor" ||
+    var.region == "jp-tok")
     error_message = "Value of region must be one of eu-gb/br-sao/ca-tor/jp-tok."
   }
 }

--- a/terraform-hpvs/nginx-hello/user_data/terraform.tf
+++ b/terraform-hpvs/nginx-hello/user_data/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     hpcr = {
       source  = "ibm-hyper-protect/hpcr"
-      version = ">= 0.1.1"
+      version = ">= 0.1.4"
     }
   }
 }

--- a/terraform-hpvs/postgresql-cluster/terraform.tf
+++ b/terraform-hpvs/postgresql-cluster/terraform.tf
@@ -193,7 +193,7 @@ resource "ibm_is_subnet" "postgres_subnet_slave_1" {
 # construct the VSI
 resource "ibm_is_instance" "postgres_vsi_slave_1" {
   name      = format("%s-slave-vsi-%s", var.prefix, var.zone_slave_1)
-  image     = local.hyper_protect_image.id
+  image     = data.hpcr_image.hyper_protect_image.image
   profile   = var.profile
   keys      = ["${ibm_is_ssh_key.postgres_sshkey.id}"]
   vpc       = ibm_is_vpc.postgres_vpc.id
@@ -225,7 +225,7 @@ resource "ibm_is_subnet" "postgres_subnet_slave_2" {
 }
 resource "ibm_is_instance" "postgres_vsi_slave_2" {
   name      = format("%s-slave-vsi-%s", var.prefix, var.zone_slave_2)
-  image     = local.hyper_protect_image.id
+  image     = data.hpcr_image.hyper_protect_image.image
   profile   = var.profile
   keys      = ["${ibm_is_ssh_key.postgres_sshkey.id}"]
   vpc       = ibm_is_vpc.postgres_vpc.id

--- a/terraform-hpvs/postgresql-cluster/variables.tf
+++ b/terraform-hpvs/postgresql-cluster/variables.tf
@@ -1,42 +1,42 @@
 variable "ibmcloud_api_key" {
   description = "Enter your IBM Cloud API Key, you can get your IBM Cloud API key using: https://cloud.ibm.com/iam#/apikeys"
-  default = "*********"
+  default     = "*********"
 }
 
 variable "region" {
   type        = string
   description = "Region to deploy to, e.g. eu-gb."
-  default = "us-south"
+  default     = "us-south"
 }
 
 variable "zone_master" {
   type        = string
   description = "Zone to deploy master to, e.g. 1."
-  default = "1"
+  default     = "1"
 }
 
 variable "zone_slave_1" {
   type        = string
   description = "Zone to deploy slave_1 to, e.g. 2."
-  default = "2"
+  default     = "2"
 }
 
 variable "zone_slave_2" {
   type        = string
   description = "Zone to deploy slave_2 to, e.g. 3."
-  default = "3"
+  default     = "3"
 }
 
 variable "logdna_ingestion_key" {
   type        = string
   description = "Ingestion key for IBM Log Analysis instance. This can be obtained from 'Linux/Ubuntu' section of 'Logging resource' tab of IBM Log Analysis instance"
-  default = "******"
+  default     = "******"
 }
 
 variable "logdna_ingestion_hostname" {
   type        = string
   description = "rsyslog endpoint of IBM Log Analysis instance. Don't include the port. Example: syslog-a.<region>.logging.cloud.ibm.com"
-  default = "syslog-***.logging.cloud.ibm.com"
+  default     = "syslog-***.logging.cloud.ibm.com"
 }
 
 variable "prefix" {

--- a/terraform-hpvs/postgresql/terraform.tf
+++ b/terraform-hpvs/postgresql/terraform.tf
@@ -6,15 +6,15 @@ terraform {
     }
     hpcr = {
       source  = "ibm-hyper-protect/hpcr"
-      version = ">= 0.1.1"
+      version = ">= 0.1.4"
     }
   }
 }
 # make sure to target the correct region and zone
 provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
-  region = var.region
-  zone   = "${var.region}-${var.zone}"
+  region           = var.region
+  zone             = "${var.region}-${var.zone}"
 }
 locals {
   # some reusable tags that identify the resources created by his sample
@@ -42,10 +42,10 @@ resource "ibm_is_security_group_rule" "postgres_inbound" {
   group     = ibm_is_security_group.postgres_security_group.id
   direction = "inbound"
   remote    = "0.0.0.0/0"
-   tcp {
-      port_min = 5432
-      port_max = 5432
-    }
+  tcp {
+    port_min = 5432
+    port_max = 5432
+  }
 }
 # the subnet
 resource "ibm_is_subnet" "postgres_subnet" {
@@ -81,30 +81,31 @@ locals {
 }
 resource "ibm_is_ssh_key" "postgres_sshkey" {
   name       = "key-terr"
-  public_key = "${file(var.ssh_public_key)}"
+  public_key = file(var.ssh_public_key)
   tags       = local.tags
 }
-# Locate the latest hyper protect image
+# locate all public image
 data "ibm_is_images" "hyper_protect_images" {
   visibility = "public"
   status     = "available"
 }
-locals {
-  # Filter the available images down to the hyper protect one
-  hyper_protect_image = [for each in data.ibm_is_images.hyper_protect_images.images : each if each.os == "hyper-protect-1-0-s390x" && each.architecture == "s390x"][0]
+
+# locate the latest hyper protect image
+data "hpcr_image" "hyper_protect_image" {
+  images = jsonencode(data.ibm_is_images.hyper_protect_images.images)
 }
 resource "hpcr_contract_encrypted" "contract" {
   contract = local.contract
 }
 # construct the VSI
 resource "ibm_is_instance" "postgres_vsi" {
-  name    = format("%s-vsi", var.prefix)
-  image   = local.hyper_protect_image.id
-  profile = var.profile
-  keys    = ["${ibm_is_ssh_key.postgres_sshkey.id}"]
-  vpc     = ibm_is_vpc.postgres_vpc.id
-  tags    = local.tags
-  zone    = "${var.region}-${var.zone}"
+  name      = format("%s-vsi", var.prefix)
+  image     = data.hpcr_image.hyper_protect_image.image
+  profile   = var.profile
+  keys      = ["${ibm_is_ssh_key.postgres_sshkey.id}"]
+  vpc       = ibm_is_vpc.postgres_vpc.id
+  tags      = local.tags
+  zone      = "${var.region}-${var.zone}"
   user_data = hpcr_contract_encrypted.contract.rendered
   primary_network_interface {
     name            = "eth0"
@@ -113,10 +114,10 @@ resource "ibm_is_instance" "postgres_vsi" {
   }
 }
 resource "ibm_is_floating_ip" "postgres_fip" {
-  name    = format("%s-vsi", var.prefix)
-  target  = ibm_is_instance.postgres_vsi.primary_network_interface[0].id  
-  }
-output "sshcommand"{
-  value = resource.ibm_is_floating_ip.postgres_fip.address
+  name   = format("%s-vsi", var.prefix)
+  target = ibm_is_instance.postgres_vsi.primary_network_interface[0].id
+}
+output "sshcommand" {
+  value       = resource.ibm_is_floating_ip.postgres_fip.address
   description = "The public IP address of the VSI"
 }

--- a/terraform-hpvs/postgresql/variables.tf
+++ b/terraform-hpvs/postgresql/variables.tf
@@ -1,26 +1,26 @@
 variable "ibmcloud_api_key" {
   description = "Enter your IBM Cloud API Key, you can get your IBM Cloud API key using: https://cloud.ibm.com/iam#/apikeys"
-  default = "********"
+  default     = "********"
 }
 variable "region" {
   type        = string
   description = "Region to deploy to, e.g. eu-gb."
-  default = "us-south"
+  default     = "us-south"
 }
 variable "zone" {
   type        = string
   description = "Zone to deploy to, e.g. 2."
-  default = "2"
+  default     = "2"
 }
 variable "logdna_ingestion_key" {
   type        = string
   description = "Ingestion key for IBM Log Analysis instance. This can be obtained from 'Linux/Ubuntu' section of 'Logging resource' tab of IBM Log Analysis instance"
-  default = "******"
+  default     = "******"
 }
 variable "logdna_ingestion_hostname" {
   type        = string
   description = "rsyslog endpoint of IBM Log Analysis instance. Don't include the port. Example: syslog-a.<region>.logging.cloud.ibm.com"
-  default = "syslog-***.logging.cloud.ibm.com"
+  default     = "syslog-***.logging.cloud.ibm.com"
 }
 variable "prefix" {
   type        = string


### PR DESCRIPTION
Leverage the `hpcr_image` datasource from the latest https://registry.terraform.io/providers/ibm-hyper-protect/hpcr/latest/docs provider to select the HPCR image in VPC. 
This gets rid of the rather hardcoded assumption that the latest image was that returned at index `0` by the VPC REST APIs.

Also apply `terraform fmt` for consistent formatting.