### PR TITLE
chore: Fix typo in sample tf-vars to make it valid again

### DIFF
--- a/terraform-hpvs/hello-world/my-settings.auto.tfvars-template
+++ b/terraform-hpvs/hello-world/my-settings.auto.tfvars-template
@@ -1,7 +1,7 @@
 ibmcloud_api_key="Your IBM Cloud API key"
 region="ca-tor" # Region to deploy to. Options include eu-gb, jp-tok, br-sao, ca-tor, us-east
 zone="2" # Zone within region to create the HPVS into.
-logdna_ingestion_key="Your LogDNA ingestion key". # You can find this in "Linux/ubuntu" section of `Logging sources` tab of "IBM Log Analysis" instance in [cloud.ibm.com](https://cloud.ibm.com)
+logdna_ingestion_key="Your LogDNA ingestion key" # You can find this in "Linux/ubuntu" section of `Logging sources` tab of "IBM Log Analysis" instance in [cloud.ibm.com](https://cloud.ibm.com)
 logdna_ingestion_hostname="rsyslog endpoint of IBM Log Analysis instance"
 # Example: "syslog-a.<log_region>.logging.cloud.ibm.com". Where <log_region> is
 # the region on which IBM Log Analysis is deployed


### PR DESCRIPTION
The `.` after the quotes results in a TF linting error.