### PR TITLE
Allow setting the resource_group during vsi creation & deletion

### DIFF
--- a/ansible-webserver/create.yml
+++ b/ansible-webserver/create.yml
@@ -24,6 +24,7 @@
         name: "{{ name_prefix }}-vpc"
         state: available
         id: "{{ vpc.id | default(omit) }}"
+        resource_group: "{{ resource_group }}"
       register: vpc_create_output
 
     - name: Configure Security Group Rule to open SSH and web server on the VSI
@@ -56,6 +57,7 @@
         vpc: "{{ vpc.id }}"
         total_ipv4_address_count: "{{ total_ipv4_address_count }}"
         zone: "{{ zone }}"
+        resource_group: "{{ resource_group }}"
       register: subnet_create_output
 
     - name: Save VPC Subnet as fact
@@ -70,6 +72,7 @@
         name: "{{ ssh_key_name }}"
         public_key: "{{ ssh_public_key }}"
         id: "{{ ssh_key.id | default(omit) }}"
+        resource_group: "{{ resource_group }}"
       register: ssh_key_create_output
 
     - name: Save SSH Key as fact
@@ -78,17 +81,29 @@
         cacheable: True
         ssh_key: "{{ ssh_key_create_output.resource }}"
 
-    - name: Retrieve image list
-      when: image_dict is undefined
-      ibm_is_images_info:
-      register: images_list
+    ## FIXME - ibm_is_images_info doesn't return anything! 
+    #
+    #
+    # - name: Retrieve image list
+    #   # when: image_dict is undefined
+    #   ibm_is_images_info:
+    #     # resource_group: "{{ resource_group }}"
+    #   register: images_list
 
-    - name: Set VM image name/id dictionary fact
-      when: image_dict is undefined
-      set_fact:
-        cacheable: True
-        image_dict: "{{ images_list.resource.images |
-                        items2dict(key_name='name', value_name='id') }}"
+    # - name: show image_dict
+    #   debug:
+    #     var: images_list
+
+    # - name: Set VM image name/id dictionary fact
+    #   when: image_dict is undefined
+    #   set_fact:
+    #     cacheable: True
+    #     image_dict: "{{ images_list.resource.images |
+    #                     items2dict(key_name='name', value_name='id') }}"
+    
+    # - name: show image_dict
+    #   debug:
+    #     var: image_dict
 
     - name: Create VSI
       when: (vsi is undefined) or (vsi == None) or (not cache_vsi)
@@ -98,12 +113,14 @@
         id: "{{ vsi.id | default(omit) }}"
         vpc: "{{ vpc.id }}"
         profile: "{{ instance.profile }}"
-        image: "{{ (image_dict|dict2items|selectattr('key', 'match', instance.image)|list|last).value }}"
+        # image: "{{ (image_dict|dict2items|selectattr('key', 'match', instance.image)|list|last).value }}"
+        image: r018-6d668004-2cdf-47ee-8efe-abbe8b8b578a
         keys:
           - "{{ ssh_key.id }}"
         primary_network_interface:
           - subnet: "{{ subnet.id }}"
         zone: "{{ zone }}"
+        resource_group: "{{ resource_group }}"
       register: vsi_create_output
 
     - name: Save VSI as fact
@@ -119,6 +136,7 @@
         state: available
         id: "{{ fip.id | default(omit) }}"
         target: "{{ vsi.primary_network_interface[0]['id'] }}"
+        resource_group: "{{ resource_group }}"
       register: fip_create_output
 
     - name: Save Floating IP as fact
@@ -155,7 +173,7 @@
       register: sysinfo
 
     - name: Print OS information
-      when: sysinfo is defined
+      when: sysinfo.stdout_lines is defined
       debug:
         var: sysinfo.stdout_lines
 

--- a/ansible-webserver/destroy.yml
+++ b/ansible-webserver/destroy.yml
@@ -17,6 +17,8 @@
       ibm_is_floating_ip:
         state: absent
         id: "{{ fip.id }}"
+        resource_group: "{{ resource_group }}"
+        target: "{{ vsi.primary_network_interface[0]['id'] }}"
       when: (fip is defined) and (fip != None)
 
     - name: Remove Floating IP fact
@@ -31,12 +33,14 @@
         id: "{{ vsi.id }}"
         vpc: "{{ vpc.id }}"
         profile: "{{ instance.profile }}"
-        image: "{{ (image_dict|dict2items|selectattr('key', 'match', instance.image)|list|first).value }}"
+        # image: "{{ (image_dict|dict2items|selectattr('key', 'match', instance.image)|list|first).value }}"
+        image: r018-6d668004-2cdf-47ee-8efe-abbe8b8b578a
         keys:
           - "{{ ssh_key.id }}"
         primary_network_interface:
           - subnet: "{{ subnet.id }}"
         zone: "{{ zone }}"
+        resource_group: "{{ resource_group }}"
       when: (vsi is defined) and (vsi != None)
 
     - name: Remove VSI fact
@@ -49,16 +53,19 @@
     #   ibm_is_ssh_key:
     #     state: absent
     #     id: "{{ ssh_key.id }}"
+    #     resource_group: "{{ resource_group }}"
     #   when: ssh_key is defined
 
     # - name: Remove VPC Subnet
     #   ibm_is_subnet:
     #     state: absent
     #     id: "{{ subnet.id }}"
+    #     resource_group: "{{ resource_group }}"
     #   when: subnet is defined
 
     # - name: Remove VPC
     #   ibm_is_vpc:
     #     state: absent
     #     id: "{{ vpc.id }}"
+    #     resource_group: "{{ resource_group }}"
     #   when: vpc is defined

--- a/ansible-webserver/group_vars/all.yml
+++ b/ansible-webserver/group_vars/all.yml
@@ -11,11 +11,11 @@ name_prefix: "{{ os_type }}-ansible"
 # - Regular expression for the VSI image name
 #    Note: If multiple matches are found the first one is taken
 instance-zlinux:
-  name: zlinux-vsi
+  name: "{{ name_prefix }}-zlinux-vsi"
   profile: bz2-2x8
   image: .*ubuntu-18-04.*s390x.*
 instance-zos:
-  name: "zos-vsi"
+  name: "{{ name_prefix }}-zos-vsi"
   profile: mz2-2x16
   image: .*zos.*
   username: IBMUSER
@@ -44,3 +44,6 @@ zone: "{{region}}-1"
 # If cache_vsi=True then VSI creation will only be attempted if not cached
 #cache_vsi: True
 cache_vsi: False
+
+# The resource group ID to be used under the IBM Cloud Account
+resource_group: "8d923eb7bb0a450baa9bafb46aba797e"


### PR DESCRIPTION
### Changes
- Enabled a task-level `resource_group` field to allow users to use non-default resource groups
- Properly skip `Print OS information` task during creation of z/OS VSIs
- Added required `target` parameter to ibm_is_floating_ip` task during destroy
- Prepended VSI name variable with `name_prefix` as described in comment field for `name_prefix`
- Added new `resource_group` variable to group vars

### Additional Notes
- Usage of the `ibm_is_images_info` seemed to hang in my execution, commented out and added `FIXME` tags, current PR needs to be updated to remove the hardcoded image ID
- Rather than using the `resource_group` variable, we should be able to set an environment variable `IC_RESOURCE_GROUP`, though attempting to export the variable in my shell, or directly in the ansible playbook `env` block didn't work as expected!