### PR TITLE
feat: add terraform example to provision HPVS with contract expiry

### DIFF
--- a/terraform-hpvs/contract-expiry/README.md
+++ b/terraform-hpvs/contract-expiry/README.md
@@ -1,0 +1,73 @@
+## Contract generation with contract expiry example
+
+This sample creates an encrypted and signed contract with expiry enabled and stores it locally in a file. In addition this example identifies
+the latest version of HPCR in the VPC cloud and then downloads the matching encryption certifcicate.
+
+### Prerequisite
+
+Prepare your environment according to [these steps](../README.md)
+
+### Settings
+
+#### Prerequisites
+
+1. Generate private key using the following commnad:
+    ```bash
+    openssl genrsa -out private.pem 4096
+    ```
+2. Generate CA private key using the following command:
+    ```bash
+    openssl genrsa -out personal_ca.key 2048
+    ```
+3. Generate CA certificate using the following command:
+    ```bash
+    openssl req -new -x509 -days 365 -key personal_ca.key -out personal_ca.crt
+    ```
+
+Use one of the following options to set your settings:
+
+#### Template file
+
+1. Copy contents of `my-settings.auto.tfvars-template` to `my-settings.auto.tfvars`.
+    ```bash
+    cp my-settings.auto.tfvars-template my-settings.auto.tfvars
+    ```
+2. Update `my-settings.auto.tfvars` to appropriate values.
+
+#### Environment variables
+
+Set the following environment variables:
+
+```text
+TF_VAR_logdna_ingestion_key="<logdna ingestion key>"
+TF_VAR_logdna_ingestion_hostname="<logdna hostname>"
+
+TF_VAR_hpcr_csr_country="<CSR - Country>"
+TF_VAR_hpcr_csr_state="<CSR - State>"
+TF_VAR_hpcr_csr_location="<CSR - Location>"
+TF_VAR_hpcr_csr_org="<CSR - Organisation>"
+TF_VAR_hpcr_csr_unit="<CSR - Unit>"
+TF_VAR_hpcr_csr_domain="<CSR - Domain>"
+TF_VAR_hpcr_csr_mail="<CSR - Mail>"
+
+TF_VAR_hpcr_private_key_path="<Private key path>"
+TF_VAR_hpcr_contract_expiry_days=<Expiry days>
+TF_VAR_hpcr_ca_privatekey_path="<CA private key path>"
+TF_VAR_hpcr_cacert_path="<CA certificate path>"
+```
+
+### Run the Example
+
+Initialize terraform:
+
+```bash
+terraform init
+```
+
+Deploy the example:
+
+```bash
+terraform apply
+```
+
+The contract will be persisted in the `build/contract.yml` folder for further use.

--- a/terraform-hpvs/contract-expiry/compose/docker-compose.yml
+++ b/terraform-hpvs/contract-expiry/compose/docker-compose.yml
@@ -1,0 +1,3 @@
+services:
+  helloworld:
+    image: docker.io/library/hello-world@sha256:4f53e2564790c8e7856ec08e384732aa38dc43c52f02952483e3f003afbf23db

--- a/terraform-hpvs/contract-expiry/my-settings.auto.tfvars-template
+++ b/terraform-hpvs/contract-expiry/my-settings.auto.tfvars-template
@@ -1,0 +1,15 @@
+logdna_ingestion_key="<logdna-ingestion-key>"
+logdna_ingestion_hostname="<logdna-hostname>"
+
+hpcr_csr_country="<CSR - Country>"
+hpcr_csr_state="<CSR - State>"
+hpcr_csr_location="<CSR - Location>"
+hpcr_csr_org="<CSR - Organisation>"
+hpcr_csr_unit="<CSR - Unit>"
+hpcr_csr_domain="<CSR - Domain>"
+hpcr_csr_mail="<CSR - Mail>"
+
+hpcr_private_key_path="<Private key path>"
+hpcr_contract_expiry_days=<Expiry days>
+hpcr_ca_privatekey_path="<CA private key path>"
+hpcr_cacert_path="<CA certificate path>"

--- a/terraform-hpvs/contract-expiry/terraform.tf
+++ b/terraform-hpvs/contract-expiry/terraform.tf
@@ -1,0 +1,57 @@
+terraform {
+  required_providers {
+    hpcr = {
+      source  = "ibm-hyper-protect/hpcr"
+      version = ">= 0.5.0"
+    }
+  }
+}
+
+resource "hpcr_tgz" "contract" {
+  folder = "compose"
+}
+
+locals {
+  # contract in clear text
+  contract = yamlencode({
+    "env" : {
+      "type" : "env",
+      "logging" : {
+        "logDNA" : {
+          "ingestionKey" : var.logdna_ingestion_key,
+          "hostname" : var.logdna_ingestion_hostname,
+        },
+      },
+    },
+    "workload" : {
+      "type" : "workload",
+      "compose" : {
+        "archive" : hpcr_tgz.contract.rendered
+      }
+    }
+  })
+
+  csrParams = {
+    "country": var.hpcr_csr_country,
+    "state":  var.hpcr_csr_state,
+    "location":  var.hpcr_csr_location,
+    "org":  var.hpcr_csr_org,
+    "unit":  var.hpcr_csr_unit,
+    "domain":  var.hpcr_csr_domain,
+    "mail": var.hpcr_csr_mail
+  }
+}
+
+resource "hpcr_contract_encrypted_contract_expiry" "contract" {
+  contract = local.contract
+  privkey= file(var.hpcr_private_key_path)
+  expiry = var.hpcr_contract_expiry_days
+  cakey = file(var.hpcr_ca_privatekey_path)
+  cacert = file(var.hpcr_cacert_path)
+  csrparams = local.csrParams
+}
+
+resource "local_file" "contract" {
+  content  = hpcr_contract_encrypted_contract_expiry.contract.rendered
+  filename = "${path.module}/build/contract.yml"
+}

--- a/terraform-hpvs/contract-expiry/variables.tf
+++ b/terraform-hpvs/contract-expiry/variables.tf
@@ -1,0 +1,74 @@
+variable "hpcr_private_key_path" {
+  type = string
+  description = "Path of private key for signature"
+}
+
+variable "hpcr_ca_privatekey_path" {
+  type = string
+  description = "Path to CA private key"
+}
+
+variable "hpcr_cacert_path" {
+  type = string
+  description = "Path to CA certificate"
+}
+
+variable "hpcr_csr_country" {
+  type = string
+  description = "HPCR CSR country"
+}
+
+variable "hpcr_csr_state" {
+  type = string
+  description = "HPCR CSR state"
+}
+
+variable "hpcr_csr_location" {
+  type = string
+  description = "HPCR CSR location"
+}
+
+variable "hpcr_csr_org" {
+  type = string
+  description = "HPCR CSR org"
+}
+
+variable "hpcr_csr_unit" {
+  type = string
+  description = "HPCR CSR unit"
+}
+
+variable "hpcr_csr_domain" {
+  type = string
+  description = "HPCR CSR domain"
+}
+
+variable "hpcr_csr_mail" {
+  type = string
+  description = "HPCR CSR Mail ID"
+}
+
+variable "hpcr_contract_expiry_days" {
+  type = number
+  description = "Number of days for contract to expire"
+}
+
+variable "logdna_ingestion_key" {
+  type        = string
+  sensitive   = true
+  description = <<-DESC
+                  Ingestion key for IBM Log Analysis instance. This can be 
+                  obtained from "Linux/Ubuntu" section of "Logging resource" 
+                  tab of IBM Log Analysis instance
+                DESC
+}
+
+variable "logdna_ingestion_hostname" {
+  type        = string
+  description = <<-DESC
+                  rsyslog endpoint of IBM Log Analysis instance. 
+                  Don't include the port. Example: 
+                  syslog-a.<log_region>.logging.cloud.ibm.com
+                  log_region is the region where IBM Log Analysis is deployed
+                DESC
+}


### PR DESCRIPTION
Contract expiry has been enabled in the latest HPCR Terraform provider. This PR adds an example for this feature for customers to refer.