### PR TITLE
fix: acpi error for ubuntu 24.04 host

### DIFF
--- a/terraform-hpvs/nginx-hello/README.md
+++ b/terraform-hpvs/nginx-hello/README.md
@@ -105,9 +105,9 @@ Deploy the example:
 terraform apply
 ```
 
-This will create a secure-execution virtual machine on your on-premise host. If you registered a libvirt hook for port fowarding to your host, you can use the IP address of the host to access the example.
+This will create a secure-execution virtual machine on your on-premise host. If you registered a libvirt hook for port forwarding to your host, you can use the IP address of the host to access the example.
 
-Note: If the `terraform apply` is failing with the following error. Add `<xsl:template match="acpi"/>` to the `domain_update.xsl` file. The `domain_update.xsl` has been updated with this change.
+Note: If the `terraform apply` is failing with the following error. Add `<xsl:template match="acpi"/>` to the `domain_update.xsl` file. The [domain_update.xsl](https://github.com/ibm-hyper-protect/linuxone-vsi-automation-samples/blob/master/terraform-hpvs/nginx-hello/onprem/domain_update.xsl) has been updated with this change. Refer the file for more details.
 
 ```
 Error: error defining libvirt domain: unsupported configuration: machine type 's390-ccw-virtio-noble' does not support ACPI

--- a/terraform-hpvs/nginx-hello/README.md
+++ b/terraform-hpvs/nginx-hello/README.md
@@ -107,6 +107,12 @@ terraform apply
 
 This will create a secure-execution virtual machine on your on-premise host. If you registered a libvirt hook for port fowarding to your host, you can use the IP address of the host to access the example.
 
+Note: If the `terraform apply` is failing with the following error. Add `<xsl:template match="acpi"/>` to the `domain_update.xsl` file. The `domain_update.xsl` has been updated with this change.
+
+```
+Error: error defining libvirt domain: unsupported configuration: machine type 's390-ccw-virtio-noble' does not support ACPI
+```
+
 #### Test if the example works
 
 Use your browser to access:

--- a/terraform-hpvs/nginx-hello/onprem/domain_update.xsl
+++ b/terraform-hpvs/nginx-hello/onprem/domain_update.xsl
@@ -30,6 +30,8 @@
       <driver name="vhost" iommu="on"/>
     </xsl:copy>
   </xsl:template>
+
+  <xsl:template match="acpi"/>
   
   <xsl:template match="/domain/devices/controller[@type='virtio-serial']"/>
   <xsl:template match="/domain/devices/channel"/>


### PR DESCRIPTION
The on prem terraform example is failing on Ubuntu 24.04 host. The error is as follows

```
libvirt_domain.sashwatk_onprem_compose_domain: Still creating... [20s elapsed]
╷
│ Error: error defining libvirt domain: unsupported configuration: machine type 's390-ccw-virtio-noble' does not support ACPI
│ 
│   with libvirt_domain.sashwatk_onprem_compose_domain,
│   on terraform.tf line 160, in resource "libvirt_domain" "sashwatk_onprem_compose_domain":
│  160: resource "libvirt_domain" "sashwatk_onprem_compose_domain" {
│ 
╵
```

The error can be fixed by adding `<xsl:template match="acpi"/>` to the `domain_update.xsl` file. This PR updates the `domain_update.xsl` and readme with the relevant information.

This change has been tested in Ubuntu 24.04 and RHEL 8.8. The results show that the libvirt terraform provider is able to create HPVS instances.

Issue raised in libvirt terraform provider - https://github.com/dmacvicar/terraform-provider-libvirt/issues/1094
Discussion in libvirt terraform provider - https://github.com/dmacvicar/terraform-provider-libvirt/discussions/1101