### PR TITLE
chore: update all examples from LogDNA to ICL

### DIFF
--- a/terraform-hpvs/README.md
+++ b/terraform-hpvs/README.md
@@ -5,7 +5,7 @@
 1. Make sure to have the [OpenSSL](https://www.openssl.org/) binary installed (see [details](#openssl))
 2. Install the [terraform CLI](https://learn.hashicorp.com/tutorials/terraform/install-cli) for your environment
 3. Follow the description for the [IBM Cloud Provider](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs#authentication) to get your API key
-4. Follow the description for [HPCR](https://cloud.ibm.com/docs/vpc?topic=vpc-about-se#hpcr_setup_logging) to setup a logging instance.
+4. Follow the description for [HPCR](https://cloud.ibm.com/docs/vpc?topic=vpc-logging-for-hyper-protect-virtual-servers-for-vpc) to setup a logging instance.
 5. Set either environment variables or fill the template file according to the example README
 
 ## Examples

--- a/terraform-hpvs/attestation/README.md
+++ b/terraform-hpvs/attestation/README.md
@@ -4,7 +4,7 @@ This sample deploys the [attestation](https://hub.docker.com/_/attestation) exam
 
 ### Prerequisite
 
-Prepare your environment according to [these steps](../README.md)
+Prepare your environment according to [these steps](../README.md). Make sure to setup IBM Cloud Logs Instance.
 
 ### Settings
 
@@ -23,8 +23,8 @@ Set the following environment variables:
 IC_API_KEY=
 TF_VAR_zone=
 TF_VAR_region=
-TF_VAR_logdna_ingestion_key=
-TF_VAR_logdna_ingestion_hostname=
+TF_VAR_icl_iam_apikey=
+TF_VAR_icl_hostname=
 ```
 
 ### Run the Example
@@ -41,32 +41,7 @@ Deploy the example:
 terraform apply
 ```
 
-This will create a sample virtual server instance. Monitor your logDNA instance for
-
-```text
-hpcr-sample-attestation-vsi compose-helloworld-1 info
-hpcr-sample-attestation-vsi compose-helloworld-1 info Hello from Docker!
-hpcr-sample-attestation-vsi compose-helloworld-1 info This message shows that your installation appears to be working correctly.
-hpcr-sample-attestation-vsi compose-helloworld-1 info
-hpcr-sample-attestation-vsi compose-helloworld-1 info To generate this message, Docker took the following steps:
-hpcr-sample-attestation-vsi compose-helloworld-1 info 1. The Docker client contacted the Docker daemon.
-hpcr-sample-attestation-vsi compose-helloworld-1 info 2. The Docker daemon pulled the "attestation" image from the Docker Hub.
-hpcr-sample-attestation-vsi compose-helloworld-1 info     (s390x)
-hpcr-sample-attestation-vsi compose-helloworld-1 info 3. The Docker daemon created a new container from that image which runs the
-hpcr-sample-attestation-vsi compose-helloworld-1 info     executable that produces the output you are currently reading.
-hpcr-sample-attestation-vsi compose-helloworld-1 info 4. The Docker daemon streamed that output to the Docker client, which sent it
-hpcr-sample-attestation-vsi compose-helloworld-1 info     to your terminal.
-hpcr-sample-attestation-vsi compose-helloworld-1 info
-hpcr-sample-attestation-vsi compose-helloworld-1 info To try something more ambitious, you can run an Ubuntu container with:
-hpcr-sample-attestation-vsi compose-helloworld-1 info $ docker run -it ubuntu bash
-hpcr-sample-attestation-vsi compose-helloworld-1 info
-hpcr-sample-attestation-vsi compose-helloworld-1 info Share images, automate workflows, and more with a free Docker ID:
-hpcr-sample-attestation-vsi compose-helloworld-1 info https://hub.docker.com/
-hpcr-sample-attestation-vsi compose-helloworld-1 info
-hpcr-sample-attestation-vsi compose-helloworld-1 info For more examples and ideas, visit:
-hpcr-sample-attestation-vsi compose-helloworld-1 info https://docs.docker.com/get-started/
-hpcr-sample-attestation-vsi compose-helloworld-1 info
-```
+This will create a sample virtual server instance. Monitor your ICL instance for logs.
 
 Destroy the created resources:
 

--- a/terraform-hpvs/attestation/my-settings.auto.tfvars-template
+++ b/terraform-hpvs/attestation/my-settings.auto.tfvars-template
@@ -1,8 +1,5 @@
 ibmcloud_api_key="Your IBM Cloud API key"
 region="ca-tor" # Region to deploy to. Options include eu-gb, jp-tok, br-sao, ca-tor, us-east
 zone="2" # Zone within region to create the HPVS into.
-logdna_ingestion_key="Your LogDNA ingestion key" # You can find this in "Linux/ubuntu" section of `Logging sources` tab of "IBM Log Analysis" instance in [cloud.ibm.com](https://cloud.ibm.com)
-logdna_ingestion_hostname="rsyslog endpoint of IBM Log Analysis instance"
-# Example: "syslog-a.<log_region>.logging.cloud.ibm.com". Where <log_region> is
-# the region on which IBM Log Analysis is deployed
-# Any other variable you want to set (see variables.tf)
+icl_hostname="Your ICL hostname"
+icl_iam_apikey="Your IBM Cloud API key"

--- a/terraform-hpvs/attestation/terraform.tf
+++ b/terraform-hpvs/attestation/terraform.tf
@@ -122,9 +122,9 @@ locals {
     "env" : {
       "type" : "env",
       "logging" : {
-        "logDNA" : {
-          "ingestionKey" : var.logdna_ingestion_key,
-          "hostname" : var.logdna_ingestion_hostname,
+        "logRouter" : {
+          "hostname" : var.icl_hostname,
+          "iamApiKey" : var.icl_iam_apikey,
         }
       },
       "env" : {

--- a/terraform-hpvs/attestation/variables.tf
+++ b/terraform-hpvs/attestation/variables.tf
@@ -33,23 +33,19 @@ variable "zone" {
   }
 }
 
-variable "logdna_ingestion_key" {
+variable "icl_hostname" {
   type        = string
   sensitive   = true
   description = <<-DESC
-                  Ingestion key for IBM Log Analysis instance. This can be 
-                  obtained from "Linux/Ubuntu" section of "Logging resource" 
-                  tab of IBM Log Analysis instance
+                  Host of IBM Cloud Logs. This can be
+                  obtained from cloud logs tab under Logging instances
                 DESC
 }
 
-variable "logdna_ingestion_hostname" {
+variable "icl_iam_apikey" {
   type        = string
   description = <<-DESC
-                  rsyslog endpoint of IBM Log Analysis instance. 
-                  Don't include the port. Example: 
-                  syslog-a.<log_region>.logging.cloud.ibm.com
-                  log_region is the region where IBM Log Analysis is deployed
+                  This can be obtained from Access(IAM) under Manage
                 DESC
 }
 

--- a/terraform-hpvs/attestation/variables.tf
+++ b/terraform-hpvs/attestation/variables.tf
@@ -35,7 +35,6 @@ variable "zone" {
 
 variable "icl_hostname" {
   type        = string
-  sensitive   = true
   description = <<-DESC
                   Host of IBM Cloud Logs. This can be
                   obtained from cloud logs tab under Logging instances
@@ -44,6 +43,7 @@ variable "icl_hostname" {
 
 variable "icl_iam_apikey" {
   type        = string
+  sensitive   = true
   description = <<-DESC
                   This can be obtained from Access(IAM) under Manage
                 DESC

--- a/terraform-hpvs/contract-expiry/README.md
+++ b/terraform-hpvs/contract-expiry/README.md
@@ -5,7 +5,7 @@ the latest version of HPCR in the VPC cloud and then downloads the matching encr
 
 ### Prerequisite
 
-Prepare your environment according to [these steps](../README.md)
+Prepare your environment according to [these steps](../README.md). Make sure to setup IBM Cloud Logs Instance.
 
 ### Settings
 
@@ -39,8 +39,8 @@ Use one of the following options to set your settings:
 Set the following environment variables:
 
 ```text
-TF_VAR_logdna_ingestion_key="<logdna ingestion key>"
-TF_VAR_logdna_ingestion_hostname="<logdna hostname>"
+TF_VAR_icl_iam_apikey="<ICL IAM Key>"
+TF_VAR_icl_hostname="<ICL Hostname>"
 
 TF_VAR_hpcr_csr_country="<CSR - Country>"
 TF_VAR_hpcr_csr_state="<CSR - State>"

--- a/terraform-hpvs/contract-expiry/my-settings.auto.tfvars-template
+++ b/terraform-hpvs/contract-expiry/my-settings.auto.tfvars-template
@@ -1,5 +1,5 @@
-logdna_ingestion_key="<logdna-ingestion-key>"
-logdna_ingestion_hostname="<logdna-hostname>"
+icl_hostname="<ICL hostname>"
+icl_iam_apikey="<IBM Cloud API key>"
 
 hpcr_csr_country="<CSR - Country>"
 hpcr_csr_state="<CSR - State>"

--- a/terraform-hpvs/contract-expiry/terraform.tf
+++ b/terraform-hpvs/contract-expiry/terraform.tf
@@ -17,9 +17,9 @@ locals {
     "env" : {
       "type" : "env",
       "logging" : {
-        "logDNA" : {
-          "ingestionKey" : var.logdna_ingestion_key,
-          "hostname" : var.logdna_ingestion_hostname,
+        "logRouter" : {
+          "hostname" : var.icl_hostname,
+          "iamApiKey" : var.icl_iam_apikey,
         },
       },
     },

--- a/terraform-hpvs/contract-expiry/variables.tf
+++ b/terraform-hpvs/contract-expiry/variables.tf
@@ -53,22 +53,18 @@ variable "hpcr_contract_expiry_days" {
   description = "Number of days for contract to expire"
 }
 
-variable "logdna_ingestion_key" {
+variable "icl_hostname" {
   type        = string
   sensitive   = true
   description = <<-DESC
-                  Ingestion key for IBM Log Analysis instance. This can be 
-                  obtained from "Linux/Ubuntu" section of "Logging resource" 
-                  tab of IBM Log Analysis instance
+                  Host of IBM Cloud Logs. This can be
+                  obtained from cloud logs tab under Logging instances
                 DESC
 }
 
-variable "logdna_ingestion_hostname" {
+variable "icl_iam_apikey" {
   type        = string
   description = <<-DESC
-                  rsyslog endpoint of IBM Log Analysis instance. 
-                  Don't include the port. Example: 
-                  syslog-a.<log_region>.logging.cloud.ibm.com
-                  log_region is the region where IBM Log Analysis is deployed
+                  This can be obtained from Access(IAM) under Manage
                 DESC
 }

--- a/terraform-hpvs/contract-expiry/variables.tf
+++ b/terraform-hpvs/contract-expiry/variables.tf
@@ -55,7 +55,6 @@ variable "hpcr_contract_expiry_days" {
 
 variable "icl_hostname" {
   type        = string
-  sensitive   = true
   description = <<-DESC
                   Host of IBM Cloud Logs. This can be
                   obtained from cloud logs tab under Logging instances
@@ -64,6 +63,7 @@ variable "icl_hostname" {
 
 variable "icl_iam_apikey" {
   type        = string
+  sensitive   = true
   description = <<-DESC
                   This can be obtained from Access(IAM) under Manage
                 DESC

--- a/terraform-hpvs/create-contract-download-encryption/README.md
+++ b/terraform-hpvs/create-contract-download-encryption/README.md
@@ -5,7 +5,7 @@ the latest version of HPCR in the VPC cloud and then downloads the matching encr
 
 ### Prerequisite
 
-Prepare your environment according to [these steps](../README.md)
+Prepare your environment according to [these steps](../README.md).  Make sure to setup IBM Cloud Logs Instance.
 
 ### Settings
 
@@ -21,8 +21,8 @@ Use one of the following options to set you settings:
 Set the following environment variables:
 
 ```text
-TF_VAR_logdna_ingestion_key=
-TF_VAR_logdna_ingestion_hostname=
+TF_VAR_icl_iam_apikey=
+TF_VAR_icl_hostname=
 ```
 
 ### Run the Example

--- a/terraform-hpvs/create-contract-download-encryption/my-settings.auto.tfvars-template
+++ b/terraform-hpvs/create-contract-download-encryption/my-settings.auto.tfvars-template
@@ -1,5 +1,2 @@
-logdna_ingestion_key="Your LogDNA ingestion key". # You can find this in "Linux/ubuntu" section of `Logging sources` tab of "IBM Log Analysis" instance in [cloud.ibm.com](https://cloud.ibm.com)
-logdna_ingestion_hostname="rsyslog endpoint of IBM Log Analysis instance"
-# Example: "syslog-a.<log_region>.logging.cloud.ibm.com". Where <log_region> is
-# the region on which IBM Log Analysis is deployed
-# Any other variable you want to set (see variables.tf)
+icl_hostname="Your ICL hostname"
+icl_iam_apikey="Your IBM Cloud API key"

--- a/terraform-hpvs/create-contract-download-encryption/terraform.tf
+++ b/terraform-hpvs/create-contract-download-encryption/terraform.tf
@@ -47,9 +47,9 @@ locals {
     "env" : {
       "type" : "env",
       "logging" : {
-        "logDNA" : {
-          "ingestionKey" : var.logdna_ingestion_key,
-          "hostname" : var.logdna_ingestion_hostname,
+        "logRouter" : {
+          "hostname" : var.icl_hostname,
+          "iamApiKey" : var.icl_iam_apikey,
         }
       }
     },

--- a/terraform-hpvs/create-contract-download-encryption/variables.tf
+++ b/terraform-hpvs/create-contract-download-encryption/variables.tf
@@ -1,6 +1,5 @@
 variable "icl_hostname" {
   type        = string
-  sensitive   = true
   description = <<-DESC
                   Host of IBM Cloud Logs. This can be
                   obtained from cloud logs tab under Logging instances
@@ -9,6 +8,7 @@ variable "icl_hostname" {
 
 variable "icl_iam_apikey" {
   type        = string
+  sensitive   = true
   description = <<-DESC
                   This can be obtained from Access(IAM) under Manage
                 DESC

--- a/terraform-hpvs/create-contract-download-encryption/variables.tf
+++ b/terraform-hpvs/create-contract-download-encryption/variables.tf
@@ -1,20 +1,16 @@
-variable "logdna_ingestion_key" {
+variable "icl_hostname" {
   type        = string
   sensitive   = true
   description = <<-DESC
-                  Ingestion key for IBM Log Analysis instance. This can be 
-                  obtained from "Linux/Ubuntu" section of "Logging resource" 
-                  tab of IBM Log Analysis instance
+                  Host of IBM Cloud Logs. This can be
+                  obtained from cloud logs tab under Logging instances
                 DESC
 }
 
-variable "logdna_ingestion_hostname" {
+variable "icl_iam_apikey" {
   type        = string
   description = <<-DESC
-                  rsyslog endpoint of IBM Log Analysis instance. 
-                  Don't include the port. Example: 
-                  syslog-a.<log_region>.logging.cloud.ibm.com
-                  log_region is the region where IBM Log Analysis is deployed
+                  This can be obtained from Access(IAM) under Manage
                 DESC
 }
 

--- a/terraform-hpvs/create-contract-dynamic-registry/README.md
+++ b/terraform-hpvs/create-contract-dynamic-registry/README.md
@@ -5,13 +5,13 @@ The contract will define the container registry and the credentials for pulling 
 
 ### Prerequisite
 
-Prepare your environment according to [these steps](../README.md)
+Prepare your environment according to [these steps](../README.md). Make sure to setup IBM Cloud Logs Instance.
 
 ### Define your settings
 
 Define your settings:
-- logdna_ingestion_hostname: The ingestion host name of your Log instance which you provisioned previously
-- logdna_ingestion_key: The ingestion key of your Log instance
+- icl_hostname: The host name of your ICL Log instance which you provisioned previously
+- icl_iam_apikey: The API key of your Log instance
 - registry: The container registry to pull your workload container image from
 - pull_username: The container registry username for pulling your workload container image
 - pull_password: The container registry password for pulling your workload container image
@@ -30,8 +30,8 @@ Use one of the following options to define the variables:
 Set the following environment variables:
 
 ```text
-TF_VAR_logdna_ingestion_key=
-TF_VAR_logdna_ingestion_hostname=
+TF_VAR_icl_iam_apikey=
+TF_VAR_icl_hostname=
 TF_VAR_registry=
 TF_VAR_pull_username=
 TF_VAR_pull_password=

--- a/terraform-hpvs/create-contract-dynamic-registry/my-settings.auto.tfvars-template
+++ b/terraform-hpvs/create-contract-dynamic-registry/my-settings.auto.tfvars-template
@@ -1,6 +1,5 @@
-logdna_ingestion_key="Your LogDNA ingestion key".
-logdna_ingestion_hostname="rsyslog endpoint of IBM Log Analysis instance"   # Example: "syslog-a.<log_region>.logging.cloud.ibm.com".
+icl_hostname="Your ICL hostname"
+icl_iam_apikey="Your IBM Cloud API key"
 registry="Prefix for the dynamic registry" # e.g. docker.io/library or us.icr.io
 pull_username="Username for registry" # Username with read access to the container registry
 pull_password="Password for registry" # Password with read access to the container registry
-

--- a/terraform-hpvs/create-contract-dynamic-registry/terraform.tf
+++ b/terraform-hpvs/create-contract-dynamic-registry/terraform.tf
@@ -19,9 +19,9 @@ locals {
     "env" : {
       "type" : "env",
       "logging" : {
-        "logDNA" : {
-          "ingestionKey" : var.logdna_ingestion_key,
-          "hostname" : var.logdna_ingestion_hostname,
+        "logRouter" : {
+          "hostname" : var.icl_hostname,
+          "iamApiKey" : var.icl_iam_apikey,
         }
       },
       "auths" : {

--- a/terraform-hpvs/create-contract-dynamic-registry/variables.tf
+++ b/terraform-hpvs/create-contract-dynamic-registry/variables.tf
@@ -1,6 +1,5 @@
 variable "icl_hostname" {
   type        = string
-  sensitive   = true
   description = <<-DESC
                   Host of IBM Cloud Logs. This can be
                   obtained from cloud logs tab under Logging instances
@@ -9,6 +8,7 @@ variable "icl_hostname" {
 
 variable "icl_iam_apikey" {
   type        = string
+  sensitive   = true
   description = <<-DESC
                   This can be obtained from Access(IAM) under Manage
                 DESC

--- a/terraform-hpvs/create-contract-dynamic-registry/variables.tf
+++ b/terraform-hpvs/create-contract-dynamic-registry/variables.tf
@@ -1,20 +1,16 @@
-variable "logdna_ingestion_key" {
+variable "icl_hostname" {
   type        = string
   sensitive   = true
   description = <<-DESC
-                  Ingestion key for IBM Log Analysis instance. This can be 
-                  obtained from "Linux/Ubuntu" section of "Logging resource" 
-                  tab of IBM Log Analysis instance
+                  Host of IBM Cloud Logs. This can be
+                  obtained from cloud logs tab under Logging instances
                 DESC
 }
 
-variable "logdna_ingestion_hostname" {
+variable "icl_iam_apikey" {
   type        = string
   description = <<-DESC
-                  rsyslog endpoint of IBM Log Analysis instance. 
-                  Don't include the port. Example: 
-                  syslog-a.<log_region>.logging.cloud.ibm.com
-                  log_region is the region where IBM Log Analysis is deployed
+                  This can be obtained from Access(IAM) under Manage
                 DESC
 }
 

--- a/terraform-hpvs/create-contract/README.md
+++ b/terraform-hpvs/create-contract/README.md
@@ -4,7 +4,7 @@ This sample creates an encrypted and signed contract and stores it locally in a 
 
 ### Prerequisite
 
-Prepare your environment according to [these steps](../README.md)
+Prepare your environment according to [these steps](../README.md). Make sure to setup IBM Cloud Logs Instance.
 
 ### Settings
 
@@ -20,8 +20,8 @@ Use one of the following options to set you settings:
 Set the following environment variables:
 
 ```text
-TF_VAR_logdna_ingestion_key=
-TF_VAR_logdna_ingestion_hostname=
+TF_VAR_icl_iam_apikey=
+TF_VAR_icl_hostname=
 ```
 
 ### Run the Example

--- a/terraform-hpvs/create-contract/my-settings.auto.tfvars-template
+++ b/terraform-hpvs/create-contract/my-settings.auto.tfvars-template
@@ -1,5 +1,2 @@
-logdna_ingestion_key="Your LogDNA ingestion key". # You can find this in "Linux/ubuntu" section of `Logging sources` tab of "IBM Log Analysis" instance in [cloud.ibm.com](https://cloud.ibm.com)
-logdna_ingestion_hostname="rsyslog endpoint of IBM Log Analysis instance"
-# Example: "syslog-a.<log_region>.logging.cloud.ibm.com". Where <log_region> is
-# the region on which IBM Log Analysis is deployed
-# Any other variable you want to set (see variables.tf)
+icl_hostname="Your ICL hostname"
+icl_iam_apikey="Your IBM Cloud API key"

--- a/terraform-hpvs/create-contract/terraform.tf
+++ b/terraform-hpvs/create-contract/terraform.tf
@@ -19,9 +19,9 @@ locals {
     "env" : {
       "type" : "env",
       "logging" : {
-        "logDNA" : {
-          "ingestionKey" : var.logdna_ingestion_key,
-          "hostname" : var.logdna_ingestion_hostname,
+        "logRouter" : {
+          "hostname" : var.icl_hostname,
+          "iamApiKey" : var.icl_iam_apikey,
         }
       }
     },

--- a/terraform-hpvs/create-contract/variables.tf
+++ b/terraform-hpvs/create-contract/variables.tf
@@ -1,6 +1,5 @@
 variable "icl_hostname" {
   type        = string
-  sensitive   = true
   description = <<-DESC
                   Host of IBM Cloud Logs. This can be
                   obtained from cloud logs tab under Logging instances
@@ -9,6 +8,7 @@ variable "icl_hostname" {
 
 variable "icl_iam_apikey" {
   type        = string
+  sensitive   = true
   description = <<-DESC
                   This can be obtained from Access(IAM) under Manage
                 DESC

--- a/terraform-hpvs/create-contract/variables.tf
+++ b/terraform-hpvs/create-contract/variables.tf
@@ -1,19 +1,15 @@
-variable "logdna_ingestion_key" {
+variable "icl_hostname" {
   type        = string
   sensitive   = true
   description = <<-DESC
-                  Ingestion key for IBM Log Analysis instance. This can be 
-                  obtained from "Linux/Ubuntu" section of "Logging resource" 
-                  tab of IBM Log Analysis instance
+                  Host of IBM Cloud Logs. This can be
+                  obtained from cloud logs tab under Logging instances
                 DESC
 }
 
-variable "logdna_ingestion_hostname" {
+variable "icl_iam_apikey" {
   type        = string
   description = <<-DESC
-                  rsyslog endpoint of IBM Log Analysis instance. 
-                  Don't include the port. Example: 
-                  syslog-a.<log_region>.logging.cloud.ibm.com
-                  log_region is the region where IBM Log Analysis is deployed
+                  This can be obtained from Access(IAM) under Manage
                 DESC
 }

--- a/terraform-hpvs/dynamic-registry/README.md
+++ b/terraform-hpvs/dynamic-registry/README.md
@@ -4,7 +4,7 @@ This sample deploys the [hello-world](https://hub.docker.com/_/hello-world) exam
 
 ### Prerequisite
 
-Prepare your environment according to [these steps](../README.md)
+Prepare your environment according to [these steps](../README.md). Make sure to setup IBM Cloud Logs Instance.
 
 ## Usecase
 

--- a/terraform-hpvs/dynamic-registry/my-settings.auto.tfvars-template
+++ b/terraform-hpvs/dynamic-registry/my-settings.auto.tfvars-template
@@ -1,11 +1,8 @@
 ibmcloud_api_key="Your IBM Cloud API key"
 region="ca-tor" # Region to deploy to. Options include eu-gb, jp-tok, br-sao, ca-tor, us-east
 zone="2" # Zone within region to create the HPVS into.
-logdna_ingestion_key="Your LogDNA ingestion key". # You can find this in "Linux/ubuntu" section of `Logging sources` tab of "IBM Log Analysis" instance in [cloud.ibm.com](https://cloud.ibm.com)
-logdna_ingestion_hostname="rsyslog endpoint of IBM Log Analysis instance"
-# Example: "syslog-a.<log_region>.logging.cloud.ibm.com". Where <log_region> is
-# the region on which IBM Log Analysis is deployed
-# Any other variable you want to set (see variables.tf)
+icl_hostname="Your ICL hostname"
+icl_iam_apikey="Your IBM Cloud API key"
 registry="Prefix for the dynamic registry" # e.g. docker.io/library
 pull_username="Username for registry" # Username with read access to the container registry
 pull_password="Password for registry" # Password with read access to the container registry

--- a/terraform-hpvs/dynamic-registry/terraform.tf
+++ b/terraform-hpvs/dynamic-registry/terraform.tf
@@ -87,9 +87,9 @@ locals {
     "env" : {
       "type" : "env",
       "logging" : {
-        "logDNA" : {
-          "ingestionKey" : var.logdna_ingestion_key,
-          "hostname" : var.logdna_ingestion_hostname,
+        "logRouter" : {
+          "hostname" : var.icl_hostname,
+          "iamApiKey" : var.icl_iam_apikey,
         }
       },
       "auths" : {

--- a/terraform-hpvs/dynamic-registry/variables.tf
+++ b/terraform-hpvs/dynamic-registry/variables.tf
@@ -34,23 +34,19 @@ variable "zone" {
   }
 }
 
-variable "logdna_ingestion_key" {
+variable "icl_hostname" {
   type        = string
   sensitive   = true
   description = <<-DESC
-                  Ingestion key for IBM Log Analysis instance. This can be 
-                  obtained from "Linux/Ubuntu" section of "Logging resource" 
-                  tab of IBM Log Analysis instance
+                  Host of IBM Cloud Logs. This can be
+                  obtained from cloud logs tab under Logging instances
                 DESC
 }
 
-variable "logdna_ingestion_hostname" {
+variable "icl_iam_apikey" {
   type        = string
   description = <<-DESC
-                  rsyslog endpoint of IBM Log Analysis instance. 
-                  Don't include the port. Example: 
-                  syslog-a.<log_region>.logging.cloud.ibm.com
-                  log_region is the region where IBM Log Analysis is deployed
+                  This can be obtained from Access(IAM) under Manage
                 DESC
 }
 

--- a/terraform-hpvs/dynamic-registry/variables.tf
+++ b/terraform-hpvs/dynamic-registry/variables.tf
@@ -36,7 +36,6 @@ variable "zone" {
 
 variable "icl_hostname" {
   type        = string
-  sensitive   = true
   description = <<-DESC
                   Host of IBM Cloud Logs. This can be
                   obtained from cloud logs tab under Logging instances
@@ -45,6 +44,7 @@ variable "icl_hostname" {
 
 variable "icl_iam_apikey" {
   type        = string
+  sensitive   = true
   description = <<-DESC
                   This can be obtained from Access(IAM) under Manage
                 DESC

--- a/terraform-hpvs/fhe-helayers-sdk/my-settings.auto.tfvars-template
+++ b/terraform-hpvs/fhe-helayers-sdk/my-settings.auto.tfvars-template
@@ -2,5 +2,5 @@ prefix="fhe-on-hpvs"
 ibmcloud_api_key="Your IBM Cloud API key"
 region="eu-gb"                                     # Region to deploy to. Options include eu-gb, jp-tok, br-sao, ca-tor, us-east
 zone="3"                                           # Zone within region to create the HPVS into.
-logdna_ingestion_key="Your LogDNA ingestion key"   # You can find this in "Linux/ubuntu" section of `Logging sources` tab of "IBM Log Analysis" instance in [cloud.ibm.com](https://cloud.ibm.com)
-logdna_ingestion_hostname="rsyslog endpoint of IBM Log Analysis instance"     # Example: "syslog-a.<log_region>.logging.cloud.ibm.com". Where <log_region> is the region on which IBM Log Analysis is deployed
+icl_hostname="Your ICL hostname"
+icl_iam_apikey="Your IBM Cloud API key"

--- a/terraform-hpvs/fhe-helayers-sdk/terraform.tf
+++ b/terraform-hpvs/fhe-helayers-sdk/terraform.tf
@@ -95,9 +95,9 @@ locals {
     "env" : {
       "type" : "env",
       "logging" : {
-        "logDNA" : {
-          "ingestionKey" : var.logdna_ingestion_key,
-          "hostname" : var.logdna_ingestion_hostname,
+        "logRouter" : {
+          "hostname" : var.icl_hostname,
+          "iamApiKey" : var.icl_iam_apikey,
         }
       }
     },

--- a/terraform-hpvs/fhe-helayers-sdk/variables.tf
+++ b/terraform-hpvs/fhe-helayers-sdk/variables.tf
@@ -33,23 +33,19 @@ variable "zone" {
   }
 }
 
-variable "logdna_ingestion_key" {
+variable "icl_hostname" {
   type        = string
   sensitive   = true
   description = <<-DESC
-                  Ingestion key for IBM Log Analysis instance. This can be 
-                  obtained from "Linux/Ubuntu" section of "Logging resource" 
-                  tab of IBM Log Analysis instance
+                  Host of IBM Cloud Logs. This can be
+                  obtained from cloud logs tab under Logging instances
                 DESC
 }
 
-variable "logdna_ingestion_hostname" {
+variable "icl_iam_apikey" {
   type        = string
   description = <<-DESC
-                  rsyslog endpoint of IBM Log Analysis instance. 
-                  Don't include the port. Example: 
-                  syslog-a.<log_region>.logging.cloud.ibm.com
-                  log_region is the region where IBM Log Analysis is deployed
+                  This can be obtained from Access(IAM) under Manage
                 DESC
 }
 

--- a/terraform-hpvs/fhe-helayers-sdk/variables.tf
+++ b/terraform-hpvs/fhe-helayers-sdk/variables.tf
@@ -35,7 +35,6 @@ variable "zone" {
 
 variable "icl_hostname" {
   type        = string
-  sensitive   = true
   description = <<-DESC
                   Host of IBM Cloud Logs. This can be
                   obtained from cloud logs tab under Logging instances
@@ -44,6 +43,7 @@ variable "icl_hostname" {
 
 variable "icl_iam_apikey" {
   type        = string
+  sensitive   = true
   description = <<-DESC
                   This can be obtained from Access(IAM) under Manage
                 DESC

--- a/terraform-hpvs/hello-world/README.md
+++ b/terraform-hpvs/hello-world/README.md
@@ -4,7 +4,7 @@ This sample deploys the [hello-world](https://hub.docker.com/_/hello-world) exam
 
 ### Prerequisite
 
-Prepare your environment according to [these steps](../README.md)
+Prepare your environment according to [these steps](../README.md). Make sure to setup IBM Cloud Logs Instance.
 
 ### Settings
 
@@ -23,8 +23,8 @@ Set the following environment variables:
 IC_API_KEY=
 TF_VAR_zone=
 TF_VAR_region=
-TF_VAR_logdna_ingestion_key=
-TF_VAR_logdna_ingestion_hostname=
+TF_VAR_icl_iam_apikey=
+TF_VAR_icl_hostname=
 ```
 
 ### Run the Example
@@ -41,32 +41,7 @@ Deploy the example:
 terraform apply
 ```
 
-This will create a sample virtual server instance. Monitor your logDNA instance for
-
-```text
-hpcr-sample-hello-world-vsi compose-helloworld-1 info
-hpcr-sample-hello-world-vsi compose-helloworld-1 info Hello from Docker!
-hpcr-sample-hello-world-vsi compose-helloworld-1 info This message shows that your installation appears to be working correctly.
-hpcr-sample-hello-world-vsi compose-helloworld-1 info
-hpcr-sample-hello-world-vsi compose-helloworld-1 info To generate this message, Docker took the following steps:
-hpcr-sample-hello-world-vsi compose-helloworld-1 info 1. The Docker client contacted the Docker daemon.
-hpcr-sample-hello-world-vsi compose-helloworld-1 info 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
-hpcr-sample-hello-world-vsi compose-helloworld-1 info     (s390x)
-hpcr-sample-hello-world-vsi compose-helloworld-1 info 3. The Docker daemon created a new container from that image which runs the
-hpcr-sample-hello-world-vsi compose-helloworld-1 info     executable that produces the output you are currently reading.
-hpcr-sample-hello-world-vsi compose-helloworld-1 info 4. The Docker daemon streamed that output to the Docker client, which sent it
-hpcr-sample-hello-world-vsi compose-helloworld-1 info     to your terminal.
-hpcr-sample-hello-world-vsi compose-helloworld-1 info
-hpcr-sample-hello-world-vsi compose-helloworld-1 info To try something more ambitious, you can run an Ubuntu container with:
-hpcr-sample-hello-world-vsi compose-helloworld-1 info $ docker run -it ubuntu bash
-hpcr-sample-hello-world-vsi compose-helloworld-1 info
-hpcr-sample-hello-world-vsi compose-helloworld-1 info Share images, automate workflows, and more with a free Docker ID:
-hpcr-sample-hello-world-vsi compose-helloworld-1 info https://hub.docker.com/
-hpcr-sample-hello-world-vsi compose-helloworld-1 info
-hpcr-sample-hello-world-vsi compose-helloworld-1 info For more examples and ideas, visit:
-hpcr-sample-hello-world-vsi compose-helloworld-1 info https://docs.docker.com/get-started/
-hpcr-sample-hello-world-vsi compose-helloworld-1 info
-```
+This will create a sample virtual server instance. Monitor your ICL instance for logs.
 
 Destroy the created resources:
 

--- a/terraform-hpvs/hello-world/my-settings.auto.tfvars-template
+++ b/terraform-hpvs/hello-world/my-settings.auto.tfvars-template
@@ -1,8 +1,5 @@
 ibmcloud_api_key="Your IBM Cloud API key"
 region="ca-tor" # Region to deploy to. Options include eu-gb, jp-tok, br-sao, ca-tor, us-east
 zone="2" # Zone within region to create the HPVS into.
-logdna_ingestion_key="Your LogDNA ingestion key" # You can find this in "Linux/ubuntu" section of `Logging sources` tab of "IBM Log Analysis" instance in [cloud.ibm.com](https://cloud.ibm.com)
-logdna_ingestion_hostname="rsyslog endpoint of IBM Log Analysis instance"
-# Example: "syslog-a.<log_region>.logging.cloud.ibm.com". Where <log_region> is
-# the region on which IBM Log Analysis is deployed
-# Any other variable you want to set (see variables.tf)
+icl_hostname="Your ICL hostname"
+icl_iam_apikey="Your IBM Cloud API key"

--- a/terraform-hpvs/hello-world/terraform.tf
+++ b/terraform-hpvs/hello-world/terraform.tf
@@ -87,9 +87,9 @@ locals {
     "env" : {
       "type" : "env",
       "logging" : {
-        "logDNA" : {
-          "ingestionKey" : var.logdna_ingestion_key,
-          "hostname" : var.logdna_ingestion_hostname,
+        "logRouter" : {
+          "hostname" : var.icl_hostname,
+          "iamApiKey" : var.icl_iam_apikey,
         }
       }
     },

--- a/terraform-hpvs/hello-world/variables.tf
+++ b/terraform-hpvs/hello-world/variables.tf
@@ -33,23 +33,19 @@ variable "zone" {
   }
 }
 
-variable "logdna_ingestion_key" {
+variable "icl_hostname" {
   type        = string
   sensitive   = true
   description = <<-DESC
-                  Ingestion key for IBM Log Analysis instance. This can be 
-                  obtained from "Linux/Ubuntu" section of "Logging resource" 
-                  tab of IBM Log Analysis instance
+                  Host of IBM Cloud Logs. This can be
+                  obtained from cloud logs tab under Logging instances
                 DESC
 }
 
-variable "logdna_ingestion_hostname" {
+variable "icl_iam_apikey" {
   type        = string
   description = <<-DESC
-                  rsyslog endpoint of IBM Log Analysis instance. 
-                  Don't include the port. Example: 
-                  syslog-a.<log_region>.logging.cloud.ibm.com
-                  log_region is the region where IBM Log Analysis is deployed
+                  This can be obtained from Access(IAM) under Manage
                 DESC
 }
 

--- a/terraform-hpvs/hello-world/variables.tf
+++ b/terraform-hpvs/hello-world/variables.tf
@@ -35,7 +35,6 @@ variable "zone" {
 
 variable "icl_hostname" {
   type        = string
-  sensitive   = true
   description = <<-DESC
                   Host of IBM Cloud Logs. This can be
                   obtained from cloud logs tab under Logging instances
@@ -44,6 +43,7 @@ variable "icl_hostname" {
 
 variable "icl_iam_apikey" {
   type        = string
+  sensitive   = true
   description = <<-DESC
                   This can be obtained from Access(IAM) under Manage
                 DESC

--- a/terraform-hpvs/ibm-cloud-logging/terraform.tf
+++ b/terraform-hpvs/ibm-cloud-logging/terraform.tf
@@ -21,8 +21,7 @@ locals {
       "logging" : {
         "logRouter" : {
           "hostname" : var.icl_hostname,
-          "iamApiKey" : var.icl_iam_apikey,
-          "port": 443,
+          "iamApiKey" : var.icl_iam_apikey
         }
       }
     },

--- a/terraform-hpvs/ibm-cloud-logging/variables.tf
+++ b/terraform-hpvs/ibm-cloud-logging/variables.tf
@@ -1,10 +1,10 @@
 variable "icl_iam_apikey" {
   type        = string
-  sensitive   = true
   description = "IAM Key of IBM Cloud Logs"
 }
 
 variable "icl_hostname" {
   type        = string
+  sensitive   = true
   description = "Hostname of IBM Cloud Logs Instance"
 }

--- a/terraform-hpvs/log-encryption/README.md
+++ b/terraform-hpvs/log-encryption/README.md
@@ -30,7 +30,7 @@ FAQ:
 
 ### Prerequisite
 
-Prepare your environment (also refer to the [generic REAME](../README.md) file):
+Prepare your environment (also refer to the [generic REAME](../README.md). Make sure to setup IBM Cloud Logs Instance.
 
 ### Settings
 
@@ -44,8 +44,8 @@ Set the following environment variables:
 IC_API_KEY=
 TF_VAR_zone=
 TF_VAR_region=
-TF_VAR_logdna_ingestion_key=
-TF_VAR_logdna_ingestion_hostname=
+TF_VAR_icl_iam_apikey=
+TF_VAR_icl_hostname=
 TF_VAR_artifactory_user=
 TF_VAR_artifactory_key=
 ```
@@ -64,12 +64,7 @@ Deploy the example:
 terraform apply
 ```
 
-This will create a sample virtual server instance. Monitor your logDNA instance for
-
-```text
-Sep 6 14:35:19 hpcr-customer-encryption-key-logging-vsi compose-logging-1 info unencrypted message
-Sep 6 14:35:19 hpcr-customer-encryption-key-logging-vsi compose-logging-1 info hyper-protect-basic.rdfpSzcyDiR7JIDgL1EiFMMmPlM6e44R916Gq44WiA0Hlwz5Mt3O2vPn66SVXAkRHWWGnTYgyLURRoKCsFs/PWcMzQLDI+M6z5H6DEVv7kAGESEmjiNxNrR3zjXHcoOBNVOgEdrZIUlI7r6eg3yN+iMz50zTm4C1j1raW6n420pr9BVcVlytP2CuAjz+nWhbK5/bkbGfrmUHVad/cduPL/ucyXwS0LQzBVFYvomSu0PqFYAQY6QxGVpmeKuUKChJ+kerIWncX2Qbao09PMZOtq9LBNqq7QxLSRcc6/MrMF2Imi8M/Ho94sRdX04zU86yEklJJhf5FMNL1FplZcE0ekWUOI0nDEo0cu8PwpCDuz9POC9+3fK5mvM1w4GrRbz5DqGb7HZF9Bq5Llw/cu5T63j52B+h9EDkUQ8wUodpcrG1+tPAfioXYLJYXbypVq+VeCrCAS+3iYJgoduQ1tcvKmm53rGL8v5TIda1tzAYXHXitVaaoheXd74P5U/2mxl6FNtOEHhDxCp7ZHMH2omyyf4pUnV+HezsMoX5c7QR9C0FqaHeSOeuLCASXuhe0Ak76RktwdQYl7AuFsT9jCMfnCUxTSSwimknTsN+PjYitaVWLnuvBlE4Q9nY3oQ35zueektWBJpzl2yDObuE07MEK69Ds0b3wPH5dxQLZtywBJw=.U2FsdGVkX18VMC96BdITb/s3ck+e7Z6rjA2HycHvzMnzivGZDMf2xk0kBc+cTEqM
-```
+This will create a sample virtual server instance. Monitor your ICL instance for logs.
 
 Destroy the created resources:
 

--- a/terraform-hpvs/log-encryption/terraform.tf
+++ b/terraform-hpvs/log-encryption/terraform.tf
@@ -104,9 +104,9 @@ locals {
     "env" : {
       "type" : "env",
       "logging" : {
-        "logDNA" : {
-          "ingestionKey" : var.logdna_ingestion_key,
-          "hostname" : var.logdna_ingestion_hostname,
+        "logRouter" : {
+          "hostname" : var.icl_hostname,
+          "iamApiKey" : var.icl_iam_apikey,
         }
       }
     },

--- a/terraform-hpvs/log-encryption/variables.tf
+++ b/terraform-hpvs/log-encryption/variables.tf
@@ -8,15 +8,20 @@ variable "zone" {
   description = "Zone to deploy to, e.g. 2."
 }
 
-variable "logdna_ingestion_key" {
+variable "icl_hostname" {
   type        = string
-  description = "Ingestion key for logDNA."
   sensitive   = true
+  description = <<-DESC
+                  Host of IBM Cloud Logs. This can be
+                  obtained from cloud logs tab under Logging instances
+                DESC
 }
 
-variable "logdna_ingestion_hostname" {
+variable "icl_iam_apikey" {
   type        = string
-  description = "Ingestion hostname (just the name not the port)."
+  description = <<-DESC
+                  This can be obtained from Access(IAM) under Manage
+                DESC
 }
 
 variable "prefix" {

--- a/terraform-hpvs/log-encryption/variables.tf
+++ b/terraform-hpvs/log-encryption/variables.tf
@@ -10,7 +10,6 @@ variable "zone" {
 
 variable "icl_hostname" {
   type        = string
-  sensitive   = true
   description = <<-DESC
                   Host of IBM Cloud Logs. This can be
                   obtained from cloud logs tab under Logging instances
@@ -19,6 +18,7 @@ variable "icl_hostname" {
 
 variable "icl_iam_apikey" {
   type        = string
+  sensitive   = true
   description = <<-DESC
                   This can be obtained from Access(IAM) under Manage
                 DESC

--- a/terraform-hpvs/mongodb/README.md
+++ b/terraform-hpvs/mongodb/README.md
@@ -4,7 +4,7 @@ This sample deploys 3 instances of [mongodb](https://hub.docker.com/r/s390x/mong
 
 ### Prerequisite
 
-Prepare your environment according to [these steps](https://github.com/ibm-hyper-protect/linuxone-vsi-automation-samples/blob/master/terraform-hpvs/README.md)
+Prepare your environment according to [these steps](https://github.com/ibm-hyper-protect/linuxone-vsi-automation-samples/blob/master/terraform-hpvs/README.md). Make sure to setup IBM Cloud Logs Instance.
 
 ### Settings
 
@@ -23,8 +23,8 @@ Set the following environment variables:
 IC_API_KEY=
 TF_VAR_zone=
 TF_VAR_region=
-TF_VAR_logdna_ingestion_key=
-TF_VAR_logdna_ingestion_hostname=
+TF_VAR_icl_iam_apikey=
+TF_VAR_icl_hostname=
 TF_VAR_mongo_user=
 TF_VAR_mongo_password=
 ```

--- a/terraform-hpvs/mongodb/my-settings.auto.tfvars-template
+++ b/terraform-hpvs/mongodb/my-settings.auto.tfvars-template
@@ -1,8 +1,8 @@
 ibmcloud_api_key = "Your IBM Cloud API key"
 region="ca-tor" # Region to deploy to. Options include eu-gb, jp-tok, br-sao, ca-tor
 zone=1 # Zone within region to create the HPVS into.
-logdna_ingestion_key="Your LogDNA ingestion key". # You can find this in "Linux/ubuntu" section of `Logging sources` tab of "IBM Log Analysis" instance in [cloud.ibm.com](https://cloud.ibm.com)
-logdna_ingestion_hostname="Your LogDNA ingestion hostname" # Example: "syslog-a.eu-gb.logging.cloud.ibm.com"
+icl_hostname="Your ICL hostname"
+icl_iam_apikey="Your IBM Cloud API key"
 mongo_user="UserID that is used to login to MongoDB instance"
 mongo_password="Password that is used to login to MongoDB instance"
 # Any other variable you want to set (see variables.tf)

--- a/terraform-hpvs/mongodb/terraform.tf
+++ b/terraform-hpvs/mongodb/terraform.tf
@@ -83,9 +83,9 @@ locals {
     "env" : {
       "type" : "env",
       "logging" : {
-        "logDNA" : {
-          "ingestionKey" : var.logdna_ingestion_key,
-          "hostname" : var.logdna_ingestion_hostname,
+        "logRouter" : {
+          "hostname" : var.icl_hostname,
+          "iamApiKey" : var.icl_iam_apikey,
         }
       },
       "env" : {

--- a/terraform-hpvs/mongodb/variables.tf
+++ b/terraform-hpvs/mongodb/variables.tf
@@ -18,22 +18,19 @@ variable "region" {
   }
 }
 
-variable "logdna_ingestion_key" {
+variable "icl_hostname" {
   type        = string
-  sensitive   = true
   description = <<-DESC
-                  Ingestion key for IBM Log Analysis instance. This can be 
-                  obtained from "Linux/Ubuntu" section of "Logging resource" 
-                  tab of IBM Log Analysis instance
+                  Host of IBM Cloud Logs. This can be
+                  obtained from cloud logs tab under Logging instances
                 DESC
 }
 
-variable "logdna_ingestion_hostname" {
+variable "icl_iam_apikey" {
   type        = string
+  sensitive   = true
   description = <<-DESC
-                  rsyslog endpoint of IBM Log Analysis instance. 
-                  Don't include the port. Example: 
-                  syslog-a.<region>.logging.cloud.ibm.com
+                  This can be obtained from Access(IAM) under Manage
                 DESC
 }
 

--- a/terraform-hpvs/nginx-hello/README.md
+++ b/terraform-hpvs/nginx-hello/README.md
@@ -4,7 +4,7 @@ This sample deploys the [nginx-hello](https://hub.docker.com/r/nginxdemos/hello/
 
 ### Prerequisite
 
-Prepare your environment according to [these steps](../README.md)
+Prepare your environment according to [these steps](../README.md). Make sure to setup IBM Cloud Logs Instance.
 
 ### Prerequisite (on-premise only)
 
@@ -33,8 +33,8 @@ Under the `cloud` directory
 IC_API_KEY=
 TF_VAR_zone=
 TF_VAR_region=
-TF_VAR_logdna_ingestion_key=
-TF_VAR_logdna_ingestion_hostname=
+TF_VAR_icl_iam_apikey=
+TF_VAR_icl_hostname=
 ```
 
 Under the `onprem` directory
@@ -43,8 +43,8 @@ TF_VAR_libvirt_host=
 TF_VAR_libvirt_user=
 TF_VAR_vsi_image=
 TF_VAR_ssh_private_key_path=
-TF_VAR_logdna_ingestion_key=
-TF_VAR_logdna_ingestion_hostname=
+TF_VAR_icl_iam_apikey=
+TF_VAR_icl_hostname=
 ```
 
 ### Run the Example

--- a/terraform-hpvs/nginx-hello/cloud/my-settings.auto.tfvars-template
+++ b/terraform-hpvs/nginx-hello/cloud/my-settings.auto.tfvars-template
@@ -1,8 +1,5 @@
 ibmcloud_api_key="Your IBM Cloud API key"
 region="ca-tor" # Region to deploy to. Options include eu-gb, jp-tok, br-sao, ca-tor, us-east
 zone="2" # Zone within region to create the HPVS into.
-logdna_ingestion_key="Your LogDNA ingestion key". # You can find this in "Linux/ubuntu" section of `Logging sources` tab of "IBM Log Analysis" instance in [cloud.ibm.com](https://cloud.ibm.com)
-logdna_ingestion_hostname="rsyslog endpoint of IBM Log Analysis instance"
-# Example: "syslog-a.<log_region>.logging.cloud.ibm.com". Where <log_region> is
-# the region on which IBM Log Analysis is deployed
-# Any other variable you want to set (see variables.tf)
+icl_hostname="Your ICL hostname"
+icl_iam_apikey="Your IBM Cloud API key"

--- a/terraform-hpvs/nginx-hello/cloud/terraform.tf
+++ b/terraform-hpvs/nginx-hello/cloud/terraform.tf
@@ -18,8 +18,8 @@ terraform {
 
 module "user_data" {
   source = "../user_data"
-  logdna_ingestion_key        = var.logdna_ingestion_key
-  logdna_ingestion_hostname   = var.logdna_ingestion_hostname
+  icl_hostname        = var.icl_hostname
+  icl_iam_apikey   = var.icl_iam_apikey
 }
 
 # make sure to target the correct region and zone

--- a/terraform-hpvs/nginx-hello/cloud/variables.tf
+++ b/terraform-hpvs/nginx-hello/cloud/variables.tf
@@ -40,22 +40,18 @@ variable "profile" {
                 DESC
 }
 
-variable "logdna_ingestion_key" {
+variable "icl_hostname" {
   type        = string
-  sensitive   = true
   description = <<-DESC
-                  Ingestion key for IBM Log Analysis instance. This can be 
-                  obtained from "Linux/Ubuntu" section of "Logging resource" 
-                  tab of IBM Log Analysis instance
+                  Host of IBM Cloud Logs. This can be
+                  obtained from cloud logs tab under Logging instances
                 DESC
 }
 
-variable "logdna_ingestion_hostname" {
+variable "icl_iam_apikey" {
   type        = string
+  sensitive   = true
   description = <<-DESC
-                  rsyslog endpoint of IBM Log Analysis instance. 
-                  Don't include the port. Example: 
-                  syslog-a.<log_region>.logging.cloud.ibm.com
-                  log_region is the region where IBM Log Analysis is deployed
+                  This can be obtained from Access(IAM) under Manage
                 DESC
 }

--- a/terraform-hpvs/nginx-hello/onprem/my-settings.auto.tfvars-template
+++ b/terraform-hpvs/nginx-hello/onprem/my-settings.auto.tfvars-template
@@ -1,8 +1,5 @@
 libvirt_host="Your libvirt host name"
 libvirt_user="User name authorized by a SSH server in your libvirt host"
 vsi_image="Path to your VSI image"
-logdna_ingestion_key="Your LogDNA ingestion key". # You can find this in "Linux/ubuntu" section of `Logging sources` tab of "IBM Log Analysis" instance in [cloud.ibm.com](https://cloud.ibm.com)
-logdna_ingestion_hostname="rsyslog endpoint of IBM Log Analysis instance"
-# Example: "syslog-a.<log_region>.logging.cloud.ibm.com". Where <log_region> is
-# the region on which IBM Log Analysis is deployed
-# Any other variable you want to set (see variables.tf)
+icl_hostname="Your ICL hostname"
+icl_iam_apikey="Your IBM Cloud API key"

--- a/terraform-hpvs/nginx-hello/onprem/terraform.tf
+++ b/terraform-hpvs/nginx-hello/onprem/terraform.tf
@@ -12,8 +12,8 @@ provider "libvirt" {
 
 module "user_data" {
   source = "../user_data"
-  logdna_ingestion_key        = var.logdna_ingestion_key
-  logdna_ingestion_hostname   = var.logdna_ingestion_hostname
+  icl_hostname        = var.icl_hostname
+  icl_iam_apikey   = var.icl_iam_apikey
 }
 
 # output the contract as a plain text (debugging purpose)

--- a/terraform-hpvs/nginx-hello/onprem/variables.tf
+++ b/terraform-hpvs/nginx-hello/onprem/variables.tf
@@ -33,7 +33,6 @@ variable "ssh_private_key_path" {
 
 variable "icl_hostname" {
   type        = string
-  sensitive   = true
   description = <<-DESC
                   Host of IBM Cloud Logs. This can be
                   obtained from cloud logs tab under Logging instances
@@ -42,6 +41,7 @@ variable "icl_hostname" {
 
 variable "icl_iam_apikey" {
   type        = string
+  sensitive   = true
   description = <<-DESC
                   This can be obtained from Access(IAM) under Manage
                 DESC

--- a/terraform-hpvs/nginx-hello/onprem/variables.tf
+++ b/terraform-hpvs/nginx-hello/onprem/variables.tf
@@ -31,22 +31,18 @@ variable "ssh_private_key_path" {
   default     = "~/.ssh/id_rsa"
 }
 
-variable "logdna_ingestion_key" {
+variable "icl_hostname" {
   type        = string
   sensitive   = true
   description = <<-DESC
-                  Ingestion key for IBM Log Analysis instance. This can be 
-                  obtained from "Linux/Ubuntu" section of "Logging resource" 
-                  tab of IBM Log Analysis instance
+                  Host of IBM Cloud Logs. This can be
+                  obtained from cloud logs tab under Logging instances
                 DESC
 }
 
-variable "logdna_ingestion_hostname" {
+variable "icl_iam_apikey" {
   type        = string
   description = <<-DESC
-                  rsyslog endpoint of IBM Log Analysis instance. 
-                  Don't include the port. Example: 
-                  syslog-a.<log_region>.logging.cloud.ibm.com
-                  log_region is the region where IBM Log Analysis is deployed
+                  This can be obtained from Access(IAM) under Manage
                 DESC
 }

--- a/terraform-hpvs/nginx-hello/user_data/my-settings.auto.tfvars-template
+++ b/terraform-hpvs/nginx-hello/user_data/my-settings.auto.tfvars-template
@@ -1,5 +1,2 @@
-logdna_ingestion_key="Your LogDNA ingestion key". # You can find this in "Linux/ubuntu" section of `Logging sources` tab of "IBM Log Analysis" instance in [cloud.ibm.com](https://cloud.ibm.com)
-logdna_ingestion_hostname="rsyslog endpoint of IBM Log Analysis instance"
-# Example: "syslog-a.<log_region>.logging.cloud.ibm.com". Where <log_region> is
-# the region on which IBM Log Analysis is deployed
-# Any other variable you want to set (see variables.tf)
+icl_hostname="Your ICL hostname"
+icl_iam_apikey="Your IBM Cloud API key"

--- a/terraform-hpvs/nginx-hello/user_data/terraform.tf
+++ b/terraform-hpvs/nginx-hello/user_data/terraform.tf
@@ -19,9 +19,9 @@ locals {
     "env" : {
       "type" : "env",
       "logging" : {
-        "logDNA" : {
-          "ingestionKey" : var.logdna_ingestion_key,
-          "hostname" : var.logdna_ingestion_hostname,
+        "logRouter" : {
+          "hostname" : var.icl_hostname,
+          "iamApiKey" : var.icl_iam_apikey,
         }
       }
     },

--- a/terraform-hpvs/nginx-hello/user_data/variables.tf
+++ b/terraform-hpvs/nginx-hello/user_data/variables.tf
@@ -1,19 +1,15 @@
-variable "logdna_ingestion_key" {
+variable "icl_hostname" {
   type        = string
-  sensitive   = true
   description = <<-DESC
-                  Ingestion key for IBM Log Analysis instance. This can be 
-                  obtained from "Linux/Ubuntu" section of "Logging resource" 
-                  tab of IBM Log Analysis instance
+                  Host of IBM Cloud Logs. This can be
+                  obtained from cloud logs tab under Logging instances
                 DESC
 }
 
-variable "logdna_ingestion_hostname" {
+variable "icl_iam_apikey" {
   type        = string
+  sensitive   = true
   description = <<-DESC
-                  rsyslog endpoint of IBM Log Analysis instance. 
-                  Don't include the port. Example: 
-                  syslog-a.<log_region>.logging.cloud.ibm.com
-                  log_region is the region where IBM Log Analysis is deployed
+                  This can be obtained from Access(IAM) under Manage
                 DESC
 }

--- a/terraform-hpvs/postgresql-cluster/README.md
+++ b/terraform-hpvs/postgresql-cluster/README.md
@@ -4,7 +4,7 @@ This deploys a simple [postgres](https://hub.docker.com/r/s390x/postgres/) clust
 
 ### Prerequisite
 
-Prepare your environment according to [these steps](https://github.com/ibm-hyper-protect/linuxone-vsi-automation-samples/blob/master/terraform-hpvs/README.md)
+Prepare your environment according to [these steps](https://github.com/ibm-hyper-protect/linuxone-vsi-automation-samples/blob/master/terraform-hpvs/README.md). Make sure to setup IBM Cloud Logs Instance.
 
 ### Settings
 
@@ -25,8 +25,8 @@ Set the default vaule of variables.tf:
 "zone_master"
 "zone_slave_1"
 "zone_slave_2"
-"logdna_ingestion_key"
-"logdna_ingestion_hostname"
+"icl_iam_apikey"
+"icl_hostname"
 "prefix"
 "profile" 
 "ssh_public_key"

--- a/terraform-hpvs/postgresql-cluster/terraform.tf
+++ b/terraform-hpvs/postgresql-cluster/terraform.tf
@@ -88,10 +88,9 @@ locals {
     "env" : {
       "type" : "env",
       "logging" : {
-        "logDNA" : {
-          "hostname" : var.logdna_ingestion_hostname,
-          "ingestionKey" : var.logdna_ingestion_key,
-          "port" : 6514,
+        "logRouter" : {
+          "hostname" : var.icl_hostname,
+          "iamApiKey" : var.icl_iam_apikey,
         }
       },
     },
@@ -162,10 +161,9 @@ locals {
     "env" : {
       "type" : "env",
       "logging" : {
-        "logDNA" : {
-          "hostname" : var.logdna_ingestion_hostname,
-          "ingestionKey" : var.logdna_ingestion_key,
-          "port" : 6514,
+        "logRouter" : {
+          "hostname" : var.icl_hostname,
+          "iamApiKey" : var.icl_iam_apikey,
         }
       },
     },

--- a/terraform-hpvs/postgresql-cluster/variables.tf
+++ b/terraform-hpvs/postgresql-cluster/variables.tf
@@ -27,16 +27,20 @@ variable "zone_slave_2" {
   default     = "3"
 }
 
-variable "logdna_ingestion_key" {
+variable "icl_hostname" {
   type        = string
-  description = "Ingestion key for IBM Log Analysis instance. This can be obtained from 'Linux/Ubuntu' section of 'Logging resource' tab of IBM Log Analysis instance"
-  default     = "******"
+  sensitive   = true
+  description = <<-DESC
+                  Host of IBM Cloud Logs. This can be
+                  obtained from cloud logs tab under Logging instances
+                DESC
 }
 
-variable "logdna_ingestion_hostname" {
+variable "icl_iam_apikey" {
   type        = string
-  description = "rsyslog endpoint of IBM Log Analysis instance. Don't include the port. Example: syslog-a.<region>.logging.cloud.ibm.com"
-  default     = "syslog-***.logging.cloud.ibm.com"
+  description = <<-DESC
+                  This can be obtained from Access(IAM) under Manage
+                DESC
 }
 
 variable "prefix" {

--- a/terraform-hpvs/postgresql-cluster/variables.tf
+++ b/terraform-hpvs/postgresql-cluster/variables.tf
@@ -29,7 +29,6 @@ variable "zone_slave_2" {
 
 variable "icl_hostname" {
   type        = string
-  sensitive   = true
   description = <<-DESC
                   Host of IBM Cloud Logs. This can be
                   obtained from cloud logs tab under Logging instances
@@ -38,6 +37,7 @@ variable "icl_hostname" {
 
 variable "icl_iam_apikey" {
   type        = string
+  sensitive   = true
   description = <<-DESC
                   This can be obtained from Access(IAM) under Manage
                 DESC

--- a/terraform-hpvs/postgresql/README.md
+++ b/terraform-hpvs/postgresql/README.md
@@ -4,7 +4,7 @@ This sample deploys one instance of [postgres](https://hub.docker.com/r/s390x/po
 ​
 ### Prerequisite
 ​
-Prepare your environment according to [these steps](https://github.com/ibm-hyper-protect/linuxone-vsi-automation-samples/blob/master/terraform-hpvs/README.md)
+Prepare your environment according to [these steps](https://github.com/ibm-hyper-protect/linuxone-vsi-automation-samples/blob/master/terraform-hpvs/README.md). Make sure to setup IBM Cloud Logs Instance.
 ​
 ### Settings
 ​
@@ -14,8 +14,8 @@ Set the default vaule of variables.tf:
 "ibmcloud_api_key"
 "region"
 "zone" 
-"logdna_ingestion_key"
-"logdna_ingestion_hostname"
+"icl_iam_apikey"
+"icl_hostname"
 "prefix"
 "profile" 
 "ssh_public_key"

--- a/terraform-hpvs/postgresql/terraform.tf
+++ b/terraform-hpvs/postgresql/terraform.tf
@@ -64,10 +64,9 @@ locals {
     "env" : {
       "type" : "env",
       "logging" : {
-        "logDNA" : {
-          "hostname" : var.logdna_ingestion_hostname,
-          "ingestionKey" : var.logdna_ingestion_key,
-          "port" : 6514,
+        "logRouter" : {
+          "hostname" : var.icl_hostname,
+          "iamApiKey" : var.icl_iam_apikey,
         }
       },
     },

--- a/terraform-hpvs/postgresql/variables.tf
+++ b/terraform-hpvs/postgresql/variables.tf
@@ -14,7 +14,6 @@ variable "zone" {
 }
 variable "icl_hostname" {
   type        = string
-  sensitive   = true
   description = <<-DESC
                   Host of IBM Cloud Logs. This can be
                   obtained from cloud logs tab under Logging instances
@@ -23,6 +22,7 @@ variable "icl_hostname" {
 
 variable "icl_iam_apikey" {
   type        = string
+  sensitive   = true
   description = <<-DESC
                   This can be obtained from Access(IAM) under Manage
                 DESC

--- a/terraform-hpvs/postgresql/variables.tf
+++ b/terraform-hpvs/postgresql/variables.tf
@@ -12,15 +12,20 @@ variable "zone" {
   description = "Zone to deploy to, e.g. 2."
   default     = "2"
 }
-variable "logdna_ingestion_key" {
+variable "icl_hostname" {
   type        = string
-  description = "Ingestion key for IBM Log Analysis instance. This can be obtained from 'Linux/Ubuntu' section of 'Logging resource' tab of IBM Log Analysis instance"
-  default     = "******"
+  sensitive   = true
+  description = <<-DESC
+                  Host of IBM Cloud Logs. This can be
+                  obtained from cloud logs tab under Logging instances
+                DESC
 }
-variable "logdna_ingestion_hostname" {
+
+variable "icl_iam_apikey" {
   type        = string
-  description = "rsyslog endpoint of IBM Log Analysis instance. Don't include the port. Example: syslog-a.<region>.logging.cloud.ibm.com"
-  default     = "syslog-***.logging.cloud.ibm.com"
+  description = <<-DESC
+                  This can be obtained from Access(IAM) under Manage
+                DESC
 }
 variable "prefix" {
   type        = string

--- a/terraform-hpvs/sample-daytrader/README.md
+++ b/terraform-hpvs/sample-daytrader/README.md
@@ -18,13 +18,13 @@ Then tag and push the resulting container image to your container registry.
 
 ### Prerequisite
 
-Prepare your local environment according to [these steps](../README.md)
+Prepare your local environment according to [these steps](../README.md). Make sure to setup IBM Cloud Logs Instance.
 
 ### Define your settings
 
 Define your settings:
-- logdna_ingestion_hostname: The ingestion host name of your Log instance which you provisioned previously
-- logdna_ingestion_key: The ingestion key of your Log instance
+- icl_hostname: The host name of your ICL Log instance which you provisioned previously
+- icl_iam_apikey: The API key of your Log instance
 - registry: The container registry where the workload container image is pulled from, e.g. `us.icr.io`
 - pull_username: The container registry username for pulling your workload container image
 - pull_password: The container registry password for pulling your workload container image

--- a/terraform-hpvs/sample-daytrader/my-settings.auto.tfvars-template
+++ b/terraform-hpvs/sample-daytrader/my-settings.auto.tfvars-template
@@ -1,5 +1,5 @@
-logdna_ingestion_key="Your LogDNA ingestion key"   # You can find this in "Linux/ubuntu" section of `Logging sources` tab of "IBM Log Analysis" instance in [cloud.ibm.com](https://cloud.ibm.com)
-logdna_ingestion_hostname="rsyslog endpoint of IBM Log Analysis instance"     # Example: "syslog-a.<log_region>.logging.cloud.ibm.com". Where <log_region> is the region on which IBM Log Analysis is deployed
+icl_hostname="Your ICL hostname"
+icl_iam_apikey="Your IBM Cloud API key"
 registry="Prefix for the dynamic registry" # e.g. docker.io/library or us.icr.io
 pull_username="Username for registry" # Username with read access to the container registry
 pull_password="Password for registry" # Password with read access to the container registry

--- a/terraform-hpvs/sample-daytrader/terraform.tf
+++ b/terraform-hpvs/sample-daytrader/terraform.tf
@@ -19,9 +19,9 @@ locals {
     "env" : {
       "type" : "env",
       "logging" : {
-        "logDNA" : {
-          "ingestionKey" : var.logdna_ingestion_key,
-          "hostname" : var.logdna_ingestion_hostname,
+        "logRouter" : {
+          "hostname" : var.icl_hostname,
+          "iamApiKey" : var.icl_iam_apikey,
         }
       },
       "auths" : {

--- a/terraform-hpvs/sample-daytrader/variables.tf
+++ b/terraform-hpvs/sample-daytrader/variables.tf
@@ -1,6 +1,5 @@
 variable "icl_hostname" {
   type        = string
-  sensitive   = true
   description = <<-DESC
                   Host of IBM Cloud Logs. This can be
                   obtained from cloud logs tab under Logging instances
@@ -9,6 +8,7 @@ variable "icl_hostname" {
 
 variable "icl_iam_apikey" {
   type        = string
+  sensitive   = true
   description = <<-DESC
                   This can be obtained from Access(IAM) under Manage
                 DESC

--- a/terraform-hpvs/sample-daytrader/variables.tf
+++ b/terraform-hpvs/sample-daytrader/variables.tf
@@ -1,20 +1,16 @@
-variable "logdna_ingestion_key" {
+variable "icl_hostname" {
   type        = string
   sensitive   = true
   description = <<-DESC
-                  Ingestion key for IBM Log Analysis instance. This can be 
-                  obtained from "Linux/Ubuntu" section of "Logging resource" 
-                  tab of IBM Log Analysis instance
+                  Host of IBM Cloud Logs. This can be
+                  obtained from cloud logs tab under Logging instances
                 DESC
 }
 
-variable "logdna_ingestion_hostname" {
+variable "icl_iam_apikey" {
   type        = string
   description = <<-DESC
-                  rsyslog endpoint of IBM Log Analysis instance. 
-                  Don't include the port. Example: 
-                  syslog-a.<log_region>.logging.cloud.ibm.com
-                  log_region is the region where IBM Log Analysis is deployed
+                  This can be obtained from Access(IAM) under Manage
                 DESC
 }
 

--- a/terraform-hpvs/sample-paynow/README.md
+++ b/terraform-hpvs/sample-paynow/README.md
@@ -7,15 +7,15 @@ For more information, see this [tutorial](https://cloud.ibm.com/docs/vpc?topic=v
 
 ### Prerequisite
 
-Prepare your local environment according to [these steps](../README.md)
+Prepare your local environment according to [these steps](../README.md). Make sure to setup IBM Cloud Logs Instance.
 
 ### Define your settings
 
 In file `compose\pod.yml` adapt the value for `image` to reference your container registry and your container image including the digest.
 
 Define your settings:
-- logdna_ingestion_hostname: The ingestion host name of your Log instance which you provisioned previously
-- logdna_ingestion_key: The ingestion key of your Log instance
+- icl_hostname: The host name of your ICL Log instance which you provisioned previously
+- icl_iam_apikey: The API key of your Log instance
 - registry: The container registry where the workload container image is pulled from, e.g. `us.icr.io`
 - pull_username: The container registry username for pulling your workload container image
 - pull_password: The container registry password for pulling your workload container image

--- a/terraform-hpvs/sample-paynow/my-settings.auto.tfvars-template
+++ b/terraform-hpvs/sample-paynow/my-settings.auto.tfvars-template
@@ -1,5 +1,5 @@
-logdna_ingestion_key="Your LogDNA ingestion key"   # You can find this in "Linux/ubuntu" section of `Logging sources` tab of "IBM Log Analysis" instance in [cloud.ibm.com](https://cloud.ibm.com)
-logdna_ingestion_hostname="rsyslog endpoint of IBM Log Analysis instance"     # Example: "syslog-a.<log_region>.logging.cloud.ibm.com". Where <log_region> is the region on which IBM Log Analysis is deployed
+icl_hostname="Your ICL hostname"
+icl_iam_apikey="Your IBM Cloud API key"
 registry="Prefix for the dynamic registry" # e.g. docker.io/library or us.icr.io
 pull_username="Username for registry" # Username with read access to the container registry
 pull_password="Password for registry" # Password with read access to the container registry

--- a/terraform-hpvs/sample-paynow/terraform.tf
+++ b/terraform-hpvs/sample-paynow/terraform.tf
@@ -19,9 +19,9 @@ locals {
     "env" : {
       "type" : "env",
       "logging" : {
-        "logDNA" : {
-          "ingestionKey" : var.logdna_ingestion_key,
-          "hostname" : var.logdna_ingestion_hostname,
+        "logRouter" : {
+          "hostname" : var.icl_hostname,
+          "iamApiKey" : var.icl_iam_apikey,
         }
       },
       "auths" : {

--- a/terraform-hpvs/sample-paynow/variables.tf
+++ b/terraform-hpvs/sample-paynow/variables.tf
@@ -1,6 +1,5 @@
 variable "icl_hostname" {
   type        = string
-  sensitive   = true
   description = <<-DESC
                   Host of IBM Cloud Logs. This can be
                   obtained from cloud logs tab under Logging instances
@@ -9,6 +8,7 @@ variable "icl_hostname" {
 
 variable "icl_iam_apikey" {
   type        = string
+  sensitive   = true
   description = <<-DESC
                   This can be obtained from Access(IAM) under Manage
                 DESC

--- a/terraform-hpvs/sample-paynow/variables.tf
+++ b/terraform-hpvs/sample-paynow/variables.tf
@@ -1,20 +1,16 @@
-variable "logdna_ingestion_key" {
+variable "icl_hostname" {
   type        = string
   sensitive   = true
   description = <<-DESC
-                  Ingestion key for IBM Log Analysis instance. This can be 
-                  obtained from "Linux/Ubuntu" section of "Logging resource" 
-                  tab of IBM Log Analysis instance
+                  Host of IBM Cloud Logs. This can be
+                  obtained from cloud logs tab under Logging instances
                 DESC
 }
 
-variable "logdna_ingestion_hostname" {
+variable "icl_iam_apikey" {
   type        = string
   description = <<-DESC
-                  rsyslog endpoint of IBM Log Analysis instance. 
-                  Don't include the port. Example: 
-                  syslog-a.<log_region>.logging.cloud.ibm.com
-                  log_region is the region where IBM Log Analysis is deployed
+                  This can be obtained from Access(IAM) under Manage
                 DESC
 }
 


### PR DESCRIPTION
Hello Team,
Updated all the LogDNA examples to ICL as LogDNA will be retired completely by Nov 30 2024.

Regards
Sashwat K